### PR TITLE
create and expose receiptData method

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -146,6 +146,17 @@ RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers
     }
 }
 
+RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
+{
+    NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSData *receiptData = [NSData dataWithContentsOfURL:receiptUrl];
+    if (!receiptData) {
+      callback(@[@"not_available"]);
+    } else {
+      callback(@[[NSNull null], [receiptData base64EncodedStringWithOptions:0]]);
+    }
+}
+
 // SKProductsRequestDelegate protocol method
 - (void)productsRequest:(SKProductsRequest *)request
      didReceiveResponse:(SKProductsResponse *)response

--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,20 @@ InAppUtils.restorePurchases((error, products)=> {
 });
 ```
 
+### Receipts
+
+iTunes receipts are associated to the users iTunes account and can be retrieved without any product reference. 
+
+```javascript
+InAppUtils.receiptData((error, receiptData)=> {
+  if(error) {
+    AlertIOS.alert('itunes Error', 'Receipt not found.');
+  } else {
+    //send to validation server
+  }
+});
+```
+
 ## Testing
 
 To test your in-app purchases, you have to *run the app on an actual device*. Using the iOS Simulator, they will always fail.


### PR DESCRIPTION
iTunes purchases are attached to the iTunes account and does not require a product identifier to retrieve.