### PR TITLE
return transactionIdentifier in success purchase

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -49,7 +49,11 @@ RCT_EXPORT_MODULE()
                 NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
                 RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
-                    callback(@[[NSNull null], transaction.payment.productIdentifier]);
+                    NSDictionary *purchase = @{
+                                              @"transactionIdentifier": transaction.transactionIdentifier,
+                                              @"productIdentifier": transaction.payment.productIdentifier
+                                              };
+                    callback(@[[NSNull null], purchase]);
                     [_callbacks removeObjectForKey:key];
                 } else {
                     RCTLogWarn(@"No callback registered for transaction with state purcahsed.");

--- a/Readme.md
+++ b/Readme.md
@@ -40,8 +40,9 @@ InAppUtils.loadProducts(products, (error, products) => {
 
 ```javascript
 var productIdentifier = 'com.xyz.abc';
-InAppUtils.purchaseProduct(productIdentifier, (error, identifier) => {
-   if(identifier) {
+InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
+   if(response) {
+      AlertIOS.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
       //unlock store here.
    }
 });


### PR DESCRIPTION
How you going with https://github.com/chirag04/react-native-in-app-utils/pull/5? I've got another one for you. This PR changes the second argument on the callback for `purchaseProduct`, it now returns an object with the `transactionIdentifier` and `productIdentifier`.

There are more details that can be added to the object, but this is a good start for now.