### PR TITLE
Handle empty localizedTitle and localDescription fields

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -175,8 +175,8 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"identifier": item.productIdentifier,
                                       @"priceString": item.priceString,
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
-                                      @"description": item.localizedDescription,
-                                      @"title": item.localizedTitle,
+                                      @"description": item.localizedDescription ? item.localizedDescription : @"",
+                                      @"title": item.localizedTitle ? item.localizedTitle : @"",
                                       };
             [productsArrayForJS addObject:product];
         }


### PR DESCRIPTION
I encountered a edge case which my in-app purchases were rejected because my binary was rejected and as a result, productsRequest returned empty values for localizedTitle and localizedDescription fields and crashed the app. This PR handles those empty fields.