### PR TITLE
Added price and currencySymbol to loadProducts response

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -173,6 +173,8 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
         for(SKProduct *item in response.products) {
             NSDictionary *product = @{
                                       @"identifier": item.productIdentifier,
+                                      @"price": item.price,
+                                      @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"priceString": item.priceString,
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",


### PR DESCRIPTION
Provide price as a number, since it's hard to parse the priceString (i.e. when presenting a yearly subscription price as the price per month). Also added currencySymbol for convenience.