### PR TITLE
Return transaction ID and original transaction ID with restore purchases

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -116,7 +116,13 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
         NSMutableArray *productsArrayForJS = [NSMutableArray array];
         for(SKPaymentTransaction *transaction in queue.transactions){
             if(transaction.transactionState == SKPaymentTransactionStateRestored) {
-                [productsArrayForJS addObject:transaction.payment.productIdentifier];
+              NSDictionary *purchase = @{
+                @"originalTransactionIdentifier": transaction.originalTransaction.transactionIdentifier,
+                @"transactionIdentifier": transaction.transactionIdentifier,
+                @"productIdentifier": transaction.payment.productIdentifier
+              };
+
+                [productsArrayForJS addObject:purchase];
                 [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
             }
         }

--- a/Readme.md
+++ b/Readme.md
@@ -90,8 +90,6 @@ InAppUtils.restorePurchases((error, response)=> {
 
 **Response:** An array of transactions with the following fields:
 
-**Response fields:**
-
 | Field                 | Type   | Description                |
 | --------------------- | ------ | -------------------------- |
 | originalTransactionIdentifier | string | The original transaction identifier |

--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 ### Restore payments
 
 ```javascript
-InAppUtils.restorePurchases((error, products)=> {
+InAppUtils.restorePurchases((error, response)=> {
    if(error) {
       AlertIOS.alert('itunes Error', 'Could not connect to itunes store.');
    } else {
@@ -88,7 +88,17 @@ InAppUtils.restorePurchases((error, products)=> {
 });
 ```
 
-**Response:** An array of product identifiers (as strings).
+**Response:** An array of transactions with the following fields:
+
+**Response fields:**
+
+| Field                 | Type   | Description                |
+| --------------------- | ------ | -------------------------- |
+| originalTransactionIdentifier | string | The original transaction identifier |
+| transactionIdentifier | string | The transaction identifier |
+| productIdentifier     | string | The product identifier |
+
+```
 
 ### Receipts
 


### PR DESCRIPTION
This changes the API of restorePurchases to return an array of objects that include the productID, transactionID and original transaction ID.
NOTE: this has nothing to do with the issue I filed yesterday (31). The suggestion there would require major changes to the API and requires more discussion.