### PR TITLE
Expose transaction receipt

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -49,7 +49,8 @@ RCT_EXPORT_MODULE()
                 if (callback) {
                     NSDictionary *purchase = @{
                                               @"transactionIdentifier": transaction.transactionIdentifier,
-                                              @"productIdentifier": transaction.payment.productIdentifier
+                                              @"productIdentifier": transaction.payment.productIdentifier,
+                                              @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
                                               };
                     callback(@[[NSNull null], purchase]);
                     [_callbacks removeObjectForKey:key];
@@ -119,7 +120,8 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
               NSDictionary *purchase = @{
                 @"originalTransactionIdentifier": transaction.originalTransaction.transactionIdentifier,
                 @"transactionIdentifier": transaction.transactionIdentifier,
-                @"productIdentifier": transaction.payment.productIdentifier
+                @"productIdentifier": transaction.payment.productIdentifier,
+                @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
               };
 
                 [productsArrayForJS addObject:purchase];

--- a/Readme.md
+++ b/Readme.md
@@ -71,10 +71,11 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 
 **Response fields:**
 
-| Field                 | Type   | Description                |
-| --------------------- | ------ | -------------------------- |
-| transactionIdentifier | string | The transaction identifier |
-| productIdentifier     | string | The product identifier |
+| Field                 | Type   | Description                                        |
+| --------------------- | ------ | -------------------------------------------------- |
+| transactionIdentifier | string | The transaction identifier                         |
+| productIdentifier     | string | The product identifier                             |
+| transactionReceipt    | string | The transaction receipt as a base64 encoded string |
 
 
 ### Restore payments
@@ -92,11 +93,12 @@ InAppUtils.restorePurchases((error, response)=> {
 
 **Response:** An array of transactions with the following fields:
 
-| Field                 | Type   | Description                |
-| --------------------- | ------ | -------------------------- |
-| originalTransactionIdentifier | string | The original transaction identifier |
-| transactionIdentifier | string | The transaction identifier |
-| productIdentifier     | string | The product identifier |
+| Field                          | Type   | Description                                        |
+| ------------------------------ | ------ | -------------------------------------------------- |
+| originalTransactionIdentifier  | string | The original transaction identifier                |
+| transactionIdentifier          | string | The transaction identifier                         |
+| productIdentifier              | string | The product identifier                             |
+| transactionReceipt             | string | The transaction receipt as a base64 encoded string |
 
 
 ### Receipts


### PR DESCRIPTION
I would like to validate receipts on a per purchase basis. This PR exposes the transaction receipt as a base64 encoded string. 

Not sure, but this might be what @a-koka was after in issue #57 as well...