### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "jain_chirag04@yahoo.com",
     "url": "http://chiragjain.tumblr.com"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:chirag04/react-native-in-app-utils.git"


### PR DESCRIPTION
This allows tools like [`yarn licenses`](https://yarnpkg.com/en/docs/cli/licenses) to automatically output the MIT license.