### PR TITLE
update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,11 +17,9 @@ A react-native wrapper for handling in-app purchases.
 
 ### Add it to your project
 
-1. Make sure you have `rnpm` installed: `npm install rnpm -g`
+1. Install with react-native: `react-native install react-native-in-app-utils`
 
-2. Install with rnpm: `rnpm install react-native-in-app-utils`
-
-3. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('NativeModules').InAppUtils;`
+2. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('NativeModules').InAppUtils;`
    or for ES6:
 
 ```


### PR DESCRIPTION
The preferred way to install react-native packages now is through react-native.  rnpm is deprecated.