### PR TITLE
Implement purchaseProductForUser and restorePurchasesForUser methods

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -233,7 +233,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
-                                      @"priceLocale": item.priceLocale.countryCode,
+                                      @"countryCode": item.priceLocale.countryCode,
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -182,7 +182,7 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
     NSString *restoreRequest = @"restoreRequest";
     _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
     if(!username) {
-        callback(@[@"no_username"]);
+        callback(@[@"username_required"]);
         return;
     }
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -181,9 +181,11 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
 {
     NSString *restoreRequest = @"restoreRequest";
     _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
-    if(username) {
-        [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
+    if(!username) {
+        callback(@[@"no_username"]);
+        return;
     }
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
 }
 
 RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -76,8 +76,22 @@ RCT_EXPORT_MODULE()
     }
 }
 
+RCT_EXPORT_METHOD(purchaseProductForUser:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:username callback:callback];
+}
+
 RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
                   callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:nil callback:callback];
+}
+
+- (void) doPurchaseProduct:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback
 {
     SKProduct *product;
     for(SKProduct *p in products)
@@ -89,7 +103,10 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
     }
 
     if(product) {
-        SKPayment *payment = [SKPayment paymentWithProduct:product];
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        if(username) {
+            payment.applicationUsername = username;
+        }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
     } else {
@@ -157,6 +174,16 @@ RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)callback)
     NSString *restoreRequest = @"restoreRequest";
     _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+}
+
+RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
+                    callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *restoreRequest = @"restoreRequest";
+    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    if(username) {
+        [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
+    }
 }
 
 RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -233,6 +233,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
+                                      @"priceLocale": item.priceLocale.countryCode,
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -235,7 +235,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
-                                      @"countryCode": item.priceLocale.countryCode,
+                                      @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,7 @@ InAppUtils.loadProducts(products, (error, products) => {
 | currencySymbol | string  | The currency symbol, i.e. "$" or "SEK"      |
 | currencyCode   | string  | The currency code, i.e. "USD" of "SEK"      |
 | priceString    | string  | Localised string of price, i.e. "$1,234.00" |
-| priceLocale    | string  | Country code of the price, i.e. "GB" or "FR"|
+| countryCode    | string  | Country code of the price, i.e. "GB" or "FR"|
 | downloadable   | boolean | Whether the purchase is downloadable        |
 | description    | string  | Description string                          |
 | title          | string  | Title string                                |

--- a/Readme.md
+++ b/Readme.md
@@ -75,6 +75,9 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 
 **NOTE:** Call `loadProducts` prior to calling `purchaseProduct`, otherwise this will return `invalid_product`. If you're calling them right after each other, you will need to call `purchaseProduct` inside of the `loadProducts` callback to ensure it has had a chance to complete its call.
 
+**NOTE:** `purchaseProductForUser(productIdentifier, username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
+
 **Response:** A transaction object with the following fields:
 
 | Field                 | Type   | Description                                        |
@@ -107,6 +110,9 @@ InAppUtils.restorePurchases((error, response) => {
    }
 });
 ```
+
+**NOTE:** `restorePurchasesForUser(username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
 
 **Response:** An array of transaction objects with the following fields:
 

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,7 @@ InAppUtils.loadProducts(products, (error, products) => {
 | currencySymbol | string  | The currency symbol, i.e. "$" or "SEK"      |
 | currencyCode   | string  | The currency code, i.e. "USD" of "SEK"      |
 | priceString    | string  | Localised string of price, i.e. "$1,234.00" |
+| priceLocale    | string  | Country code of the price, i.e. "GB" or "FR"|
 | downloadable   | boolean | Whether the purchase is downloadable        |
 | description    | string  | Description string                          |
 | title          | string  | Title string                                |


### PR DESCRIPTION
Support giving a username to purchase and restore methods to prevent mixing up double accounts in the same apple ID. 
https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858