### PR TITLE
Listen for purchase events + optional promise support + other updates

### DIFF
--- a/InAppUtils/InAppUtils.h
+++ b/InAppUtils/InAppUtils.h
@@ -2,7 +2,8 @@
 #import <StoreKit/StoreKit.h>
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface InAppUtils : NSObject <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@interface InAppUtils : RCTEventEmitter <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
 
 @end

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -63,7 +63,7 @@ shouldAddStorePayment:(SKPayment *)payment
         switch (transaction.transactionState) {
             case SKPaymentTransactionStateFailed: {
                 NSLog(@"purchase failed");
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                NSString *key = transaction.payment.productIdentifier;
                 RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
                     callback(@[RCTJSErrorFromNSError(transaction.error)]);
@@ -77,7 +77,7 @@ shouldAddStorePayment:(SKPayment *)payment
             case SKPaymentTransactionStatePurchased: {
                 NSLog(@"purchased");
                 currentTransaction = transaction;
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                NSString *key = transaction.payment.productIdentifier;
                 RCTResponseSenderBlock callback = _callbacks[key];
                 NSDictionary *purchase = [self getPurchaseData:transaction];
                 if (callback) {
@@ -141,7 +141,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
             payment.applicationUsername = username;
         }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
-        _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
+        _callbacks[payment.productIdentifier] = callback;
     } else {
         callback(@[RCTMakeError(@"invalid_product", nil, nil)]);
     }
@@ -158,7 +158,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
 - (void)paymentQueue:(SKPaymentQueue *)queue
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
-    NSString *key = RCTKeyForInstance(@"restoreRequest");
+    NSString *key = @"restoreRequest";
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
         switch (error.code)
@@ -179,7 +179,7 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
 {
-    NSString *key = RCTKeyForInstance(@"restoreRequest");
+    NSString *key = @"restoreRequest";
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
         NSMutableArray *productsArrayForJS = [NSMutableArray array];
@@ -202,7 +202,7 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)callback)
 {
     NSString *restoreRequest = @"restoreRequest";
-    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    _callbacks[restoreRequest] = callback;
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
@@ -210,7 +210,7 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
                   callback:(RCTResponseSenderBlock)callback)
 {
     NSString *restoreRequest = @"restoreRequest";
-    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    _callbacks[restoreRequest] = callback;
     if(!username) {
         callback(@[RCTMakeError(@"username_required", nil, nil)]);
         return;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -63,10 +63,11 @@ shouldAddStorePayment:(SKPayment *)payment
         switch (transaction.transactionState) {
             case SKPaymentTransactionStateFailed: {
                 NSLog(@"purchase failed");
-                RCTResponseSenderBlock callback = _callbacks[transaction.payment.productIdentifier];
+                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
                     callback(@[RCTJSErrorFromNSError(transaction.error)]);
-                    [_callbacks removeObjectForKey:transaction.payment.productIdentifier];
+                    [_callbacks removeObjectForKey:key];
                 } else {
                     RCTLogWarn(@"No callback registered for transaction with state failed.");
                 }
@@ -76,11 +77,12 @@ shouldAddStorePayment:(SKPayment *)payment
             case SKPaymentTransactionStatePurchased: {
                 NSLog(@"purchased");
                 currentTransaction = transaction;
-                RCTResponseSenderBlock callback = _callbacks[transaction.payment.productIdentifier];
+                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                RCTResponseSenderBlock callback = _callbacks[key];
                 NSDictionary *purchase = [self getPurchaseData:transaction];
                 if (callback) {
                     callback(@[[NSNull null], purchase]);
-                    [_callbacks removeObjectForKey:transaction.payment.productIdentifier];
+                    [_callbacks removeObjectForKey:key];
                 }
                 if (hasPurchaseCompletedListeners) {
                     [self sendEventWithName:@"purchaseCompleted" body:purchase];
@@ -139,7 +141,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
             payment.applicationUsername = username;
         }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
-        _callbacks[payment.productIdentifier] = callback;
+        _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
     } else {
         callback(@[RCTMakeError(@"invalid_product", nil, nil)]);
     }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -238,7 +238,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
 {
     NSString *receipt = [self grandUnifiedReceipt];
     if (receipt == nil) {
-        callback(@[@"not_available"]);
+        callback(@[RCTMakeError(@"receipt_not_available", nil, nil)]);
     } else {
         callback(@[[NSNull null], receipt]);
     }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -14,6 +14,7 @@
 - (instancetype)init
 {
     if ((self = [super init])) {
+        hasPurchaseCompletedListeners = NO;
         _callbacks = [[NSMutableDictionary alloc] init];
         [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
     }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -90,7 +90,7 @@ shouldAddStorePayment:(SKPayment *)payment
                 if (!callback && !hasPurchaseCompletedListeners) {
                     RCTLogWarn(@"No callback or listener registered for transaction with state purchased.");
                 }
-                [self finishTransaction:transaction];
+               [self finishTransaction:transaction];
                 break;
             }
             case SKPaymentTransactionStateRestored:
@@ -249,6 +249,20 @@ RCT_EXPORT_METHOD(shouldFinishTransactions:(BOOL)finishTransactions
                   callback:(RCTResponseSenderBlock)callback) {
     shouldFinishTransactions = finishTransactions;
     callback(@[[NSNull null]]);
+}
+
+RCT_EXPORT_METHOD(getPurchaseTransactions:(RCTResponseSenderBlock)callback) {
+    NSArray *transactions = [[SKPaymentQueue defaultQueue] transactions];
+    NSMutableArray *purchasedTransactions = [NSMutableArray array];
+    for (int k = 0; k < transactions.count; k++) {
+        SKPaymentTransaction *transaction = transactions[k];
+        if (transaction.transactionState == SKPaymentTransactionStatePurchased) {
+            NSDictionary *purchase = [self getPurchaseData:transaction];
+            [purchasedTransactions addObject:purchase];
+            [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+        }
+    }
+    callback(@[[NSNull null], purchasedTransactions]);
 }
 
 RCT_EXPORT_METHOD(finishCurrentTransaction:(RCTResponseSenderBlock)callback) {

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -331,14 +331,11 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
-    // Get transaction receipt
-    NSData *receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
-
     NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [receiptData base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
     } else {
-        callback(@[@"invalid_product"]);
+        callback(@[RCTMakeError(@"invalid_product", nil, nil)]);
     }
 }
 
@@ -141,10 +141,10 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
         switch (error.code)
         {
             case SKErrorPaymentCancelled:
-                callback(@[@"user_cancelled"]);
+                callback(@[RCTMakeError(@"user_cancelled", nil, nil)]);
                 break;
             default:
-                callback(@[@"restore_failed"]);
+                callback(@[RCTJSErrorFromNSError(error)]);
                 break;
         }
 
@@ -189,7 +189,7 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
     NSString *restoreRequest = @"restoreRequest";
     _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
     if(!username) {
-        callback(@[@"username_required"]);
+        callback(@[RCTMakeError(@"username_required", nil, nil)]);
         return;
     }
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
     NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
     NSData *receiptData = [NSData dataWithContentsOfURL:receiptUrl];
     if (!receiptData) {
-      callback(@[@"not_available"]);
+      callback(@[RCTMakeError(@"receipt_not_available", nil, nil)]);
     } else {
       callback(@[[NSNull null], [receiptData base64EncodedStringWithOptions:0]]);
     }
@@ -275,7 +275,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
         purchase[@"originalTransactionDate"] = @(originalTransaction.transactionDate.timeIntervalSince1970 * 1000);
         purchase[@"originalTransactionIdentifier"] = originalTransaction.transactionIdentifier;
     }
-    
+
     return purchase;
 }
 

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -331,11 +331,14 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
+    // Get transaction receipt
+    NSData *receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+
     NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": [receiptData base64EncodedStringWithOptions:0]
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -236,12 +236,22 @@ RCT_EXPORT_METHOD(canMakePayments: (RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
 {
+    NSString *receipt = [self grandUnifiedReceipt];
+    if (receipt == nil) {
+        callback(@[@"not_available"]);
+    } else {
+        callback(@[[NSNull null], receipt]);
+    }
+}
+
+- (NSString *)grandUnifiedReceipt
+{
     NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
     NSData *receiptData = [NSData dataWithContentsOfURL:receiptUrl];
     if (!receiptData) {
-        callback(@[RCTMakeError(@"receipt_not_available", nil, nil)]);
+        return nil;
     } else {
-        callback(@[[NSNull null], [receiptData base64EncodedStringWithOptions:0]]);
+        return [receiptData base64EncodedStringWithOptions:0];
     }
 }
 
@@ -307,7 +317,7 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
                                       @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
-                                      @"downloadable": item.downloadable ? @"true" : @"false" ,
+                                      @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",
                                       };
@@ -335,7 +345,7 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": [self grandUnifiedReceipt]
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -37,7 +37,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"PurchaseCompleted"];
+    return @[@"purchaseCompleted"];
 }
 
 // Transactions initiated from App Store
@@ -72,7 +72,7 @@ shouldAddStorePayment:(SKPayment *)payment
                     callback(@[[NSNull null], purchase]);
                     [_callbacks removeObjectForKey:key];
                 } else if (hasPurchaseCompletedListeners) {
-                    [self sendEventWithName:@"PurchaseCompleted" body:purchase];
+                    [self sendEventWithName:@"purchaseCompleted" body:purchase];
                 } else {
                     RCTLogWarn(@"No callback registered for transaction with state purchased.");
                 }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -63,11 +63,10 @@ shouldAddStorePayment:(SKPayment *)payment
         switch (transaction.transactionState) {
             case SKPaymentTransactionStateFailed: {
                 NSLog(@"purchase failed");
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
-                RCTResponseSenderBlock callback = _callbacks[key];
+                RCTResponseSenderBlock callback = _callbacks[transaction.payment.productIdentifier];
                 if (callback) {
                     callback(@[RCTJSErrorFromNSError(transaction.error)]);
-                    [_callbacks removeObjectForKey:key];
+                    [_callbacks removeObjectForKey:transaction.payment.productIdentifier];
                 } else {
                     RCTLogWarn(@"No callback registered for transaction with state failed.");
                 }
@@ -77,12 +76,11 @@ shouldAddStorePayment:(SKPayment *)payment
             case SKPaymentTransactionStatePurchased: {
                 NSLog(@"purchased");
                 currentTransaction = transaction;
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
-                RCTResponseSenderBlock callback = _callbacks[key];
+                RCTResponseSenderBlock callback = _callbacks[transaction.payment.productIdentifier];
                 NSDictionary *purchase = [self getPurchaseData:transaction];
                 if (callback) {
                     callback(@[[NSNull null], purchase]);
-                    [_callbacks removeObjectForKey:key];
+                    [_callbacks removeObjectForKey:transaction.payment.productIdentifier];
                 }
                 if (hasPurchaseCompletedListeners) {
                     [self sendEventWithName:@"purchaseCompleted" body:purchase];
@@ -141,7 +139,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
             payment.applicationUsername = username;
         }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
-        _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
+        _callbacks[payment.productIdentifier] = callback;
     } else {
         callback(@[RCTMakeError(@"invalid_product", nil, nil)]);
     }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers
 RCT_EXPORT_METHOD(canMakePayments: (RCTResponseSenderBlock)callback)
 {
     BOOL canMakePayments = [SKPaymentQueue canMakePayments];
-    callback(@[@(canMakePayments)]);
+    callback(@[[NSNull null], @(canMakePayments)]);
 }
 
 RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -83,10 +83,12 @@ shouldAddStorePayment:(SKPayment *)payment
                 if (callback) {
                     callback(@[[NSNull null], purchase]);
                     [_callbacks removeObjectForKey:key];
-                } else if (hasPurchaseCompletedListeners) {
+                }
+                if (hasPurchaseCompletedListeners) {
                     [self sendEventWithName:@"purchaseCompleted" body:purchase];
-                } else {
-                    RCTLogWarn(@"No callback registered for transaction with state purchased.");
+                }
+                if (!callback && !hasPurchaseCompletedListeners) {
+                    RCTLogWarn(@"No callback or listener registered for transaction with state purchased.");
                 }
                 [self finishTransaction:transaction];
                 break;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -44,7 +44,7 @@ RCT_EXPORT_MODULE()
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue
 shouldAddStorePayment:(SKPayment *)payment
           forProduct:(SKProduct *)product {
-    return true;
+    return hasPurchaseCompletedListeners;
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -311,7 +311,7 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
         products = [NSMutableArray arrayWithArray:response.products];
         NSMutableArray *productsArrayForJS = [NSMutableArray array];
         for(SKProduct *item in response.products) {
-            NSDictionary *product = @{
+            NSMutableDictionary *product = [NSMutableDictionary dictionaryWithDictionary:@{
                                       @"identifier": item.productIdentifier,
                                       @"price": item.price,
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
@@ -321,7 +321,12 @@ RCT_EXPORT_METHOD(clearCompletedTransactions:(RCTResponseSenderBlock)callback) {
                                       @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",
-                                      };
+                                      }];
+            if (@available(iOS 11.2, *)) {
+                if (item.introductoryPrice) {
+                    product[@"introPrice"] = @(item.introductoryPrice.price.floatValue) ?: @"";
+                }
+            }
             [productsArrayForJS addObject:product];
         }
         callback(@[[NSNull null], productsArrayForJS]);

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -243,7 +243,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
     }
 }
 
-RCT_EXPORT_METHOD(shouldFinishTransactions:(BOOL *)finishTransactions
+RCT_EXPORT_METHOD(shouldFinishTransactions:(BOOL)finishTransactions
                   callback:(RCTResponseSenderBlock)callback) {
     shouldFinishTransactions = finishTransactions;
     callback(@[[NSNull null]]);

--- a/Readme.md
+++ b/Readme.md
@@ -64,8 +64,8 @@ InAppUtils.loadProducts(products, (error, products) => {
 ### Checking if payments are allowed
 
 ```javascript
-InAppUtils.canMakePayments((canMakePayments) => {
-   if(!canMakePayments) {
+InAppUtils.canMakePayments((error, enabled) => {
+   if(!enabled) {
       Alert.alert('Not Allowed', 'This device is not allowed to make purchases. Please check restrictions on device');
    }
 })
@@ -165,7 +165,7 @@ InAppUtils.receiptData((error, receiptData)=> {
 Check if in-app purchases are enabled/disabled.
 
 ```javascript
-InAppUtils.canMakePayments((enabled) => {
+InAppUtils.canMakePayments((error, enabled) => {
   if(enabled) {
     Alert.alert('IAP enabled');
   } else {

--- a/Readme.md
+++ b/Readme.md
@@ -211,6 +211,50 @@ listener.remove();
 | productIdentifier     | string | The product identifier                             |
 | transactionReceipt    | string | The transaction receipt as a base64 encoded string |
 
+### Helpers
+
+```javascript
+// Accepts a boolean.
+// Transactions are (by default) automatically finished unless you call this method before the purchase.
+InAppUtils.shouldFinishTransactions(false)
+
+// Clears current transaction from queue.
+// If you call InAppUtils.shouldFinishTransactions(false) before a purchase,
+// make sure to call InAppUtils.finishCurrentTransaction() after you are done with
+// the purchase data.
+InAppUtils.finishCurrentTransaction()
+
+// Clears all transactions (that are not in a purchasing state) from queue.
+// Be carefull when you call this, especially if you are listening for purchases initiated
+// from the App Store. You might mistakenly clear these transactions.
+// Avoid calling this method on app start.
+InAppUtils.clearCompletedTransactions()
+```
+
+You should not need to use these helpers unless you are having any of the following issues or you know what you are doing:
+
+#### If users gets charged but product does not get unlocked or subscription does not get stored, then try this:
+
+```js
+await InAppUtils.shouldFinishTransactions(false)
+const purchase = await InAppUtils.purchaseProduct(...)
+
+// Here you can unlock product or save subscription...
+
+await InAppUtils.finishCurrentTransaction()
+await InAppUtils.shouldFinishTransactions(true)
+```
+
+#### Sometimes queues are not resolved and subsequent purchases fail. Then try this:
+
+```js
+// Don't call InAppUtils.clearCompletedTransactions() on app start
+// Call it just before user initiates a purchase
+await InAppUtils.clearCompletedTransactions()
+const purchase = await InAppUtils.purchaseProduct(...)
+```
+
+
 ## Testing
 
 To test your in-app purchases, you have to *run the app on an actual device*. Using the iOS Simulator, they will always fail as the simulator cannot connect to the iTunes Store. However, you can do certain tasks like using `loadProducts` without the need to run on a real device.

--- a/Readme.md
+++ b/Readme.md
@@ -178,7 +178,16 @@ InAppUtils.canMakePayments((enabled) => {
 Can be used for purchases initiated from the App Store or subscription renewals.
 
 ```javascript
-const listener = InAppUtils.addListener('PurchaseCompleted', purchase => {
+import {
+  NativeEventEmitter,
+  NativeModules,
+} from 'react-native';
+
+const { InAppUtils } = NativeModules;
+
+const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
+
+const listener = InAppUtilsEmitter.addListener('PurchaseCompleted', purchase => {
   if(purchase && purchase.productIdentifier) {
       Alert.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
       //unlock store here.

--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,13 @@ A react-native wrapper for handling in-app purchases.
 
 2. Install with rnpm: `rnpm install react-native-in-app-utils`
 
-3. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('react-native-in-app-utils');`
-   or for ES6:
+3. Whenever you want to use it within React code now you just have to do:
+
+```
+var InAppUtils = require('react-native-in-app-utils');
+```
+
+or
 
 ```
 import InAppUtils from 'react-native-in-app-utils';

--- a/Readme.md
+++ b/Readme.md
@@ -111,7 +111,7 @@ InAppUtils.restorePurchases((error, response) => {
       Alert.alert('itunes Error', 'Could not connect to itunes store.');
    } else {
       Alert.alert('Restore Successful', 'Successfully restores all your purchases.');
-      
+
       if (response.length === 0) {
         Alert.alert('No Purchases', "We didn't find any purchases to restore.");
         return;
@@ -173,6 +173,33 @@ InAppUtils.canMakePayments((enabled) => {
 
 **Response:** The enabled boolean flag.
 
+### Listen for purchase events
+
+Can be used for purchases initiated from the App Store or subscription renewals.
+
+```javascript
+const listener = InAppUtils.addListener('PurchaseCompleted', purchase => {
+  if(purchase && purchase.productIdentifier) {
+      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+      //unlock store here.
+   }
+});
+```
+
+to remove listener:
+
+```javascript
+listener.remove();
+```
+
+**Response:** A transaction object with the following fields:
+
+| Field                 | Type   | Description                                        |
+| --------------------- | ------ | -------------------------------------------------- |
+| transactionDate       | number | The transaction date (ms since epoch)              |
+| transactionIdentifier | string | The transaction identifier                         |
+| productIdentifier     | string | The product identifier                             |
+| transactionReceipt    | string | The transaction receipt as a base64 encoded string |
 
 ## Testing
 

--- a/Readme.md
+++ b/Readme.md
@@ -189,7 +189,7 @@ const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 
 const listener = InAppUtilsEmitter.addListener('PurchaseCompleted', purchase => {
   if(purchase && purchase.productIdentifier) {
-      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + purchase.transactionIdentifier);
       //unlock store here.
    }
 });

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,6 @@ or
 import InAppUtils from 'react-native-in-app-utils';
 ```
 
-
 ## API
 
 ### Loading products
@@ -41,28 +40,26 @@ import InAppUtils from 'react-native-in-app-utils';
 You have to load the products first to get the correctly internationalized name and price in the correct currency.
 
 ```javascript
-const identifiers = [
-   'com.xyz.abc',
-];
+const identifiers = ["com.xyz.abc"];
 InAppUtils.loadProducts(identifiers, (error, products) => {
-   console.log(products);
-   //update store here.
+  console.log(products);
+  //update store here.
 });
 ```
 
 **Response:** An array of product objects with the following fields:
 
-| Field          | Type    | Description                                 |
-| -------------- | ------- | ------------------------------------------- |
-| identifier     | string  | The product identifier                      |
-| price          | number  | The price as a number                       |
-| currencySymbol | string  | The currency symbol, i.e. "$" or "SEK"      |
-| currencyCode   | string  | The currency code, i.e. "USD" of "SEK"      |
-| priceString    | string  | Localised string of price, i.e. "$1,234.00" |
-| countryCode    | string  | Country code of the price, i.e. "GB" or "FR"|
-| downloadable   | boolean | Whether the purchase is downloadable        |
-| description    | string  | Description string                          |
-| title          | string  | Title string                                |
+| Field          | Type    | Description                                  |
+| -------------- | ------- | -------------------------------------------- |
+| identifier     | string  | The product identifier                       |
+| price          | number  | The price as a number                        |
+| currencySymbol | string  | The currency symbol, i.e. "\$" or "SEK"      |
+| currencyCode   | string  | The currency code, i.e. "USD" of "SEK"       |
+| priceString    | string  | Localised string of price, i.e. "\$1,234.00" |
+| countryCode    | string  | Country code of the price, i.e. "GB" or "FR" |
+| downloadable   | boolean | Whether the purchase is downloadable         |
+| description    | string  | Description string                           |
+| title          | string  | Title string                                 |
 
 **Troubleshooting:** If you do not get back your product(s) then there's a good chance that something in your iTunes Connect or Xcode is not properly configured. Take a look at this [StackOverflow Answer](http://stackoverflow.com/a/11707704/293280) to determine what might be the issue(s).
 
@@ -70,10 +67,13 @@ InAppUtils.loadProducts(identifiers, (error, products) => {
 
 ```javascript
 InAppUtils.canMakePayments((error, enabled) => {
-   if(!enabled) {
-      Alert.alert('Not Allowed', 'This device is not allowed to make purchases. Please check restrictions on device');
-   }
-})
+  if (!enabled) {
+    Alert.alert(
+      "Not Allowed",
+      "This device is not allowed to make purchases. Please check restrictions on device"
+    );
+  }
+});
 ```
 
 **NOTE:** canMakePayments may return false because of country limitation or parental contol/restriction setup on the device.
@@ -81,13 +81,16 @@ InAppUtils.canMakePayments((error, enabled) => {
 ### Buy product
 
 ```javascript
-var productIdentifier = 'com.xyz.abc';
+var productIdentifier = "com.xyz.abc";
 InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
-   // NOTE for v3.0: User can cancel the payment which will be available as error object here.
-   if(response && response.productIdentifier) {
-      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
-      //unlock store here.
-   }
+  // NOTE for v3.0: User can cancel the payment which will be available as error object here.
+  if (response && response.productIdentifier) {
+    Alert.alert(
+      "Purchase Successful",
+      "Your Transaction ID is " + response.transactionIdentifier
+    );
+    //unlock store here.
+  }
 });
 ```
 
@@ -100,37 +103,40 @@ https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-m
 
 **Response:** A transaction object with the following fields:
 
-| Field                 | Type   | Description                                        |
-| --------------------- | ------ | -------------------------------------------------- |
-| originalTransactionDate        | number | The original transaction date (ms since epoch)     |
-| originalTransactionIdentifier  | string | The original transaction identifier                |
-| transactionDate       | number | The transaction date (ms since epoch)              |
-| transactionIdentifier | string | The transaction identifier                         |
-| productIdentifier     | string | The product identifier                             |
-| transactionReceipt    | string | The transaction receipt as a base64 encoded string |
+| Field                         | Type   | Description                                        |
+| ----------------------------- | ------ | -------------------------------------------------- |
+| originalTransactionDate       | number | The original transaction date (ms since epoch)     |
+| originalTransactionIdentifier | string | The original transaction identifier                |
+| transactionDate               | number | The transaction date (ms since epoch)              |
+| transactionIdentifier         | string | The transaction identifier                         |
+| productIdentifier             | string | The product identifier                             |
+| transactionReceipt            | string | The transaction receipt as a base64 encoded string |
 
-**NOTE:**  `originalTransactionDate` and `originalTransactionIdentifier` are only available for subscriptions that were previously cancelled or expired.
+**NOTE:** `originalTransactionDate` and `originalTransactionIdentifier` are only available for subscriptions that were previously cancelled or expired.
 
 ### Restore payments
 
 ```javascript
 InAppUtils.restorePurchases((error, response) => {
-   if(error) {
-      Alert.alert('itunes Error', 'Could not connect to itunes store.');
-   } else {
-      Alert.alert('Restore Successful', 'Successfully restores all your purchases.');
+  if (error) {
+    Alert.alert("itunes Error", "Could not connect to itunes store.");
+  } else {
+    Alert.alert(
+      "Restore Successful",
+      "Successfully restores all your purchases."
+    );
 
-      if (response.length === 0) {
-        Alert.alert('No Purchases', "We didn't find any purchases to restore.");
-        return;
+    if (response.length === 0) {
+      Alert.alert("No Purchases", "We didn't find any purchases to restore.");
+      return;
+    }
+
+    response.forEach(purchase => {
+      if (purchase.productIdentifier === "com.xyz.abc") {
+        // Handle purchased product.
       }
-
-      response.forEach((purchase) => {
-        if (purchase.productIdentifier === 'com.xyz.abc') {
-          // Handle purchased product.
-        }
-      });
-   }
+    });
+  }
 });
 ```
 
@@ -139,24 +145,23 @@ https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-m
 
 **Response:** An array of transaction objects with the following fields:
 
-| Field                          | Type   | Description                                        |
-| ------------------------------ | ------ | -------------------------------------------------- |
-| originalTransactionDate        | number | The original transaction date (ms since epoch)     |
-| originalTransactionIdentifier  | string | The original transaction identifier                |
-| transactionDate                | number | The transaction date (ms since epoch)              |
-| transactionIdentifier          | string | The transaction identifier                         |
-| productIdentifier              | string | The product identifier                             |
-| transactionReceipt             | string | The transaction receipt as a base64 encoded string |
-
+| Field                         | Type   | Description                                        |
+| ----------------------------- | ------ | -------------------------------------------------- |
+| originalTransactionDate       | number | The original transaction date (ms since epoch)     |
+| originalTransactionIdentifier | string | The original transaction identifier                |
+| transactionDate               | number | The transaction date (ms since epoch)              |
+| transactionIdentifier         | string | The transaction identifier                         |
+| productIdentifier             | string | The product identifier                             |
+| transactionReceipt            | string | The transaction receipt as a base64 encoded string |
 
 ### Receipts
 
 iTunes receipts are associated to the users iTunes account and can be retrieved without any product reference.
 
 ```javascript
-InAppUtils.receiptData((error, receiptData)=> {
-  if(error) {
-    Alert.alert('itunes Error', 'Receipt not found.');
+InAppUtils.receiptData((error, receiptData) => {
+  if (error) {
+    Alert.alert("itunes Error", "Receipt not found.");
   } else {
     //send to validation server
   }
@@ -171,10 +176,10 @@ Check if in-app purchases are enabled/disabled.
 
 ```javascript
 InAppUtils.canMakePayments((error, enabled) => {
-  if(enabled) {
-    Alert.alert('IAP enabled');
+  if (enabled) {
+    Alert.alert("IAP enabled");
   } else {
-    Alert.alert('IAP disabled');
+    Alert.alert("IAP disabled");
   }
 });
 ```
@@ -186,13 +191,16 @@ InAppUtils.canMakePayments((error, enabled) => {
 Can be used for purchases initiated from the App Store or subscription renewals.
 
 ```javascript
-import InAppUtils from 'react-native-in-app-utils';
+import InAppUtils from "react-native-in-app-utils";
 
-const listener = InAppUtils.addListener('purchaseCompleted', purchase => {
-  if(purchase && purchase.productIdentifier) {
-      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + purchase.transactionIdentifier);
-      //unlock store here.
-   }
+const listener = InAppUtils.addListener("purchaseCompleted", purchase => {
+  if (purchase && purchase.productIdentifier) {
+    Alert.alert(
+      "Purchase Successful",
+      "Your Transaction ID is " + purchase.transactionIdentifier
+    );
+    //unlock store here.
+  }
 });
 ```
 
@@ -216,19 +224,22 @@ listener.remove();
 ```javascript
 // Accepts a boolean.
 // Transactions are (by default) automatically finished unless you call this method before the purchase.
-InAppUtils.shouldFinishTransactions(false)
+InAppUtils.shouldFinishTransactions(false);
 
 // Clears current transaction from queue.
 // If you call InAppUtils.shouldFinishTransactions(false) before a purchase,
 // make sure to call InAppUtils.finishCurrentTransaction() after you are done with
 // the purchase data.
-InAppUtils.finishCurrentTransaction()
+InAppUtils.finishCurrentTransaction();
+
+// Returns all completed purchase transactions in queue and removes them from the queue
+InAppUtils.getPurchaseTransactions();
 
 // Clears all transactions (that are not in a purchasing state) from queue.
 // Be carefull when you call this, especially if you are listening for purchases initiated
 // from the App Store. You might mistakenly clear these transactions.
 // Avoid calling this method on app start.
-InAppUtils.clearCompletedTransactions()
+InAppUtils.clearCompletedTransactions();
 ```
 
 You should not need to use these helpers unless you are having any of the following issues or you know what you are doing:
@@ -254,10 +265,9 @@ await InAppUtils.clearCompletedTransactions()
 const purchase = await InAppUtils.purchaseProduct(...)
 ```
 
-
 ## Testing
 
-To test your in-app purchases, you have to *run the app on an actual device*. Using the iOS Simulator, they will always fail as the simulator cannot connect to the iTunes Store. However, you can do certain tasks like using `loadProducts` without the need to run on a real device.
+To test your in-app purchases, you have to _run the app on an actual device_. Using the iOS Simulator, they will always fail as the simulator cannot connect to the iTunes Store. However, you can do certain tasks like using `loadProducts` without the need to run on a real device.
 
 1. Set up a test account ("Sandbox Tester") in iTunes Connect. See the official documentation [here](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SettingUpUserAccounts.html#//apple_ref/doc/uid/TP40011225-CH25-SW9).
 
@@ -291,11 +301,13 @@ async validate(receiptData) {
 This works on both react native and backend server, you should setup a cron job that run everyday to check if the receipt is still valid
 
 ## Free trial period for in-app-purchase
+
 There is nothing to set up related to this library.
 Instead, If you want to set up a free trial period for in-app-purchase, you have to set it up at
 iTunes Connect > your app > your in-app-purchase > free trial period (say 3-days or any period you can find from the pulldown menu)
 
 The flow we know at this point seems to be (auto-renewal case):
+
 1. FIRST, user have to 'purchase' no matter the free trial period is set or not.
 2. If the app is configured to have a free trial period, THEN user can use the app in that free trial period without being charged.
 3. When the free trial period is over, Apple's system will start to auto-renew user's purchase, therefore user can continue to use the app, but user will be charged from that point on.

--- a/Readme.md
+++ b/Readme.md
@@ -21,12 +21,11 @@ A react-native wrapper for handling in-app purchases.
 
 2. Install with rnpm: `rnpm install react-native-in-app-utils`
 
-3. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('NativeModules').InAppUtils;`
+3. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('react-native-in-app-utils');`
    or for ES6:
 
 ```
-import { NativeModules } from 'react-native'
-const { InAppUtils } = NativeModules
+import InAppUtils from 'react-native-in-app-utils';
 ```
 
 
@@ -181,16 +180,9 @@ InAppUtils.canMakePayments((error, enabled) => {
 Can be used for purchases initiated from the App Store or subscription renewals.
 
 ```javascript
-import {
-  NativeEventEmitter,
-  NativeModules,
-} from 'react-native';
+import InAppUtils from 'react-native-in-app-utils';
 
-const { InAppUtils } = NativeModules;
-
-const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
-
-const listener = InAppUtilsEmitter.addListener('PurchaseCompleted', purchase => {
+const listener = InAppUtils.addListener('PurchaseCompleted', purchase => {
   if(purchase && purchase.productIdentifier) {
       Alert.alert('Purchase Successful', 'Your Transaction ID is ' + purchase.transactionIdentifier);
       //unlock store here.

--- a/Readme.md
+++ b/Readme.md
@@ -188,7 +188,7 @@ Can be used for purchases initiated from the App Store or subscription renewals.
 ```javascript
 import InAppUtils from 'react-native-in-app-utils';
 
-const listener = InAppUtils.addListener('PurchaseCompleted', purchase => {
+const listener = InAppUtils.addListener('purchaseCompleted', purchase => {
   if(purchase && purchase.productIdentifier) {
       Alert.alert('Purchase Successful', 'Your Transaction ID is ' + purchase.transactionIdentifier);
       //unlock store here.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,43 @@
+import {
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+} from 'react-native';
+
+const { InAppUtils } = NativeModules;
+
+const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
+
+const promisify = fn => (...args) => new Promise((resolve, reject) => {
+  fn(...args, (err, res) => err ? reject(err) : resolve(res));
+});
+
+const IAU = Platform.select({
+  ios: {
+    loadProducts: (products, cb) => cb
+      ? InAppUtils.loadProducts(products, cb)
+      : promisify(InAppUtils.loadProducts)(products),
+
+    canMakePayments: cb => cb
+      ? InAppUtils.canMakePayments(cb)
+      : promisify(InAppUtils.canMakePayments)(),
+
+    purchaseProduct: (productIdentifier, cb) => cb
+      ? InAppUtils.purchaseProduct(productIdentifier, cb)
+      : promisify(InAppUtils.purchaseProduct)(productIdentifier),
+
+    restorePurchases: cb => cb
+      ? InAppUtils.restorePurchases(cb)
+      : promisify(InAppUtils.restorePurchases)(),
+
+    receiptData: cb => cb
+    ? InAppUtils.receiptData(cb)
+    : promisify(InAppUtils.receiptData)(),
+
+    addListener: (event, cb) => InAppUtilsEmitter.addListener(event, cb),
+  },
+
+  android: {},
+});
+
+export default IAU;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,12 @@ const { InAppUtils } = NativeModules;
 const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 
 const promisify = fn => (...args) => new Promise((resolve, reject) => {
-  fn(...args, (err, res) => err ? reject(err) : resolve(res));
+  fn(...args, (err, res) => {
+    if (err !== undefined && err instanceof Error) reject(err);
+    // If only one argument is given and it's not an error
+    if (err !== undefined && res === undefined) resolve(err);
+    resolve(res);
+  });
 });
 
 const IAU = Platform.select({

--- a/index.js
+++ b/index.js
@@ -9,12 +9,7 @@ const { InAppUtils } = NativeModules;
 const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 
 const promisify = fn => (...args) => new Promise((resolve, reject) => {
-  fn(...args, (err, res) => {
-    if (err !== undefined && err instanceof Error) reject(err);
-    // If only one argument is given and it's not an error
-    if (err !== undefined && res === undefined) resolve(err);
-    resolve(res);
-  });
+  fn(...args, (err, res) => err ? reject(err) : resolve(res));
 });
 
 const IAU = Platform.select({

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const IAU = Platform.select({
     ? InAppUtils.receiptData(cb)
     : promisify(InAppUtils.receiptData)(),
 
-    addListener: (event, cb) => InAppUtilsEmitter.addListener(event, cb),
+    addListener: InAppUtilsEmitter.addListener,
   },
 
   android: {},

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const IAU = Platform.select({
     ? InAppUtils.receiptData(cb)
     : promisify(InAppUtils.receiptData)(),
 
-    addListener: InAppUtilsEmitter.addListener,
+    addListener: (...args) => InAppUtilsEmitter.addListener(...args),
   },
 
   android: {},

--- a/index.js
+++ b/index.js
@@ -1,63 +1,76 @@
-import {
-  NativeEventEmitter,
-  NativeModules,
-  Platform,
-} from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from "react-native";
 
 const { InAppUtils } = NativeModules;
 
 const InAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 
-const promisify = fn => (...args) => new Promise((resolve, reject) => {
-  fn(...args, (err, res) => err ? reject(err) : resolve(res));
-});
+const promisify = fn => (...args) =>
+  new Promise((resolve, reject) => {
+    fn(...args, (err, res) => (err ? reject(err) : resolve(res)));
+  });
 
 const IAU = Platform.select({
   ios: {
-    loadProducts: (products, cb) => cb
-      ? InAppUtils.loadProducts(products, cb)
-      : promisify(InAppUtils.loadProducts)(products),
+    loadProducts: (products, cb) =>
+      cb
+        ? InAppUtils.loadProducts(products, cb)
+        : promisify(InAppUtils.loadProducts)(products),
 
-    canMakePayments: cb => cb
-      ? InAppUtils.canMakePayments(cb)
-      : promisify(InAppUtils.canMakePayments)(),
+    canMakePayments: cb =>
+      cb
+        ? InAppUtils.canMakePayments(cb)
+        : promisify(InAppUtils.canMakePayments)(),
 
-    purchaseProduct: (productIdentifier, cb) => cb
-      ? InAppUtils.purchaseProduct(productIdentifier, cb)
-      : promisify(InAppUtils.purchaseProduct)(productIdentifier),
+    purchaseProduct: (productIdentifier, cb) =>
+      cb
+        ? InAppUtils.purchaseProduct(productIdentifier, cb)
+        : promisify(InAppUtils.purchaseProduct)(productIdentifier),
 
-    purchaseProductForUser: (productIdentifier, username, cb) => cb
-      ? InAppUtils.purchaseProductForUser(productIdentifier, username, cb)
-      : promisify(InAppUtils.purchaseProductForUser)(productIdentifier, username),
+    purchaseProductForUser: (productIdentifier, username, cb) =>
+      cb
+        ? InAppUtils.purchaseProductForUser(productIdentifier, username, cb)
+        : promisify(InAppUtils.purchaseProductForUser)(
+            productIdentifier,
+            username
+          ),
 
-    restorePurchases: cb => cb
-      ? InAppUtils.restorePurchases(cb)
-      : promisify(InAppUtils.restorePurchases)(),
+    restorePurchases: cb =>
+      cb
+        ? InAppUtils.restorePurchases(cb)
+        : promisify(InAppUtils.restorePurchases)(),
 
-    restorePurchasesForUser: (username, cb) => cb
-      ? InAppUtils.restorePurchasesForUser(username, cb)
-      : promisify(InAppUtils.restorePurchasesForUser)(username),
+    restorePurchasesForUser: (username, cb) =>
+      cb
+        ? InAppUtils.restorePurchasesForUser(username, cb)
+        : promisify(InAppUtils.restorePurchasesForUser)(username),
 
-    receiptData: cb => cb
-      ? InAppUtils.receiptData(cb)
-      : promisify(InAppUtils.receiptData)(),
+    receiptData: cb =>
+      cb ? InAppUtils.receiptData(cb) : promisify(InAppUtils.receiptData)(),
 
-    shouldFinishTransactions: (finishTransactions, cb) => cb
-      ? InAppUtils.shouldFinishTransactions(finishTransactions, cb)
-      : promisify(InAppUtils.shouldFinishTransactions)(finishTransactions),
+    shouldFinishTransactions: (finishTransactions, cb) =>
+      cb
+        ? InAppUtils.shouldFinishTransactions(finishTransactions, cb)
+        : promisify(InAppUtils.shouldFinishTransactions)(finishTransactions),
 
-    finishCurrentTransaction: cb => cb
-      ? InAppUtils.finishCurrentTransaction(cb)
-      : promisify(InAppUtils.finishCurrentTransaction)(),
+    getPurchaseTransactions: cb =>
+      cb
+        ? InAppUtils.getPurchaseTransactions(cb)
+        : promisify(InAppUtils.getPurchaseTransactions)(),
 
-    clearCompletedTransactions: cb => cb
-      ? InAppUtils.clearCompletedTransactions(cb)
-      : promisify(InAppUtils.clearCompletedTransactions)(),
+    finishCurrentTransaction: cb =>
+      cb
+        ? InAppUtils.finishCurrentTransaction(cb)
+        : promisify(InAppUtils.finishCurrentTransaction)(),
 
-    addListener: (...args) => InAppUtilsEmitter.addListener(...args),
+    clearCompletedTransactions: cb =>
+      cb
+        ? InAppUtils.clearCompletedTransactions(cb)
+        : promisify(InAppUtils.clearCompletedTransactions)(),
+
+    addListener: (...args) => InAppUtilsEmitter.addListener(...args)
   },
 
-  android: {},
+  android: {}
 });
 
 export default IAU;

--- a/index.js
+++ b/index.js
@@ -26,9 +26,17 @@ const IAU = Platform.select({
       ? InAppUtils.purchaseProduct(productIdentifier, cb)
       : promisify(InAppUtils.purchaseProduct)(productIdentifier),
 
+    purchaseProductForUser: (productIdentifier, username, cb) => cb
+      ? InAppUtils.purchaseProductForUser(productIdentifier, username, cb)
+      : promisify(InAppUtils.purchaseProductForUser)(productIdentifier, username),
+
     restorePurchases: cb => cb
       ? InAppUtils.restorePurchases(cb)
       : promisify(InAppUtils.restorePurchases)(),
+
+    restorePurchasesForUser: (username, cb) => cb
+      ? InAppUtils.restorePurchasesForUser(username, cb)
+      : promisify(InAppUtils.restorePurchasesForUser)(username),
 
     receiptData: cb => cb
     ? InAppUtils.receiptData(cb)

--- a/index.js
+++ b/index.js
@@ -39,8 +39,20 @@ const IAU = Platform.select({
       : promisify(InAppUtils.restorePurchasesForUser)(username),
 
     receiptData: cb => cb
-    ? InAppUtils.receiptData(cb)
-    : promisify(InAppUtils.receiptData)(),
+      ? InAppUtils.receiptData(cb)
+      : promisify(InAppUtils.receiptData)(),
+
+    shouldFinishTransactions: (finishTransactions, cb) => cb
+      ? InAppUtils.shouldFinishTransactions(finishTransactions, cb)
+      : promisify(InAppUtils.shouldFinishTransactions)(finishTransactions),
+
+    finishCurrentTransaction: cb => cb
+      ? InAppUtils.finishCurrentTransaction(cb)
+      : promisify(InAppUtils.finishCurrentTransaction)(),
+
+    clearCompletedTransactions: cb => cb
+      ? InAppUtils.clearCompletedTransactions(cb)
+      : promisify(InAppUtils.clearCompletedTransactions)(),
 
     addListener: (...args) => InAppUtilsEmitter.addListener(...args),
   },


### PR DESCRIPTION
Updates:

- [x] Listen for purchase events initiated from App Store and subscription renewals
- [x] Support promises
- [x] `canMakePurchase` returns error arg too now *
- [x] Always return error object for errors *
- [x] Added helpers `shouldFinishTransactions`, `finishCurrentTransaction` and `clearCompletedTransactions`. See readme for more info.
- [ ] Call `addTransactionObserver` after js code initialises *

\* breaking change
  
To install and test:
```
npm i --save https://github.com/superandrew213/react-native-in-app-utils#listen-for-purchase-event
```

To trigger purchase initiated from App Store, open this link in safari. Replace `bundleId` and `productIdentifier` with your own.
```
itms-services://?action=purchaseIntent&bundleId=com.example.app&productIdentifier=product_name
```