### PR TITLE
Add manual transaction finish, getPendingPurchases

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -76,8 +76,22 @@ RCT_EXPORT_MODULE()
     }
 }
 
+RCT_EXPORT_METHOD(purchaseProductForUser:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:username callback:callback];
+}
+
 RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
                   callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:nil callback:callback];
+}
+
+- (void) doPurchaseProduct:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback
 {
     SKProduct *product;
     for(SKProduct *p in products)
@@ -89,7 +103,10 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
     }
 
     if(product) {
-        SKPayment *payment = [SKPayment paymentWithProduct:product];
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        if(username) {
+            payment.applicationUsername = username;
+        }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
     } else {
@@ -159,6 +176,18 @@ RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)callback)
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
+RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
+                    callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *restoreRequest = @"restoreRequest";
+    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    if(!username) {
+        callback(@[@"username_required"]);
+        return;
+    }
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
+}
+
 RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers
                   callback:(RCTResponseSenderBlock)callback)
 {
@@ -206,6 +235,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
+                                      @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,7 @@ InAppUtils.loadProducts(products, (error, products) => {
 | currencySymbol | string  | The currency symbol, i.e. "$" or "SEK"      |
 | currencyCode   | string  | The currency code, i.e. "USD" of "SEK"      |
 | priceString    | string  | Localised string of price, i.e. "$1,234.00" |
+| countryCode    | string  | Country code of the price, i.e. "GB" or "FR"|
 | downloadable   | boolean | Whether the purchase is downloadable        |
 | description    | string  | Description string                          |
 | title          | string  | Title string                                |
@@ -74,6 +75,9 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 ```
 
 **NOTE:** Call `loadProducts` prior to calling `purchaseProduct`, otherwise this will return `invalid_product`. If you're calling them right after each other, you will need to call `purchaseProduct` inside of the `loadProducts` callback to ensure it has had a chance to complete its call.
+
+**NOTE:** `purchaseProductForUser(productIdentifier, username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
 
 **Response:** A transaction object with the following fields:
 
@@ -107,6 +111,9 @@ InAppUtils.restorePurchases((error, response) => {
    }
 });
 ```
+
+**NOTE:** `restorePurchasesForUser(username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
 
 **Response:** An array of transaction objects with the following fields:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-in-app-utils",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "A react-native wrapper for handling in-app payments.",
   "author": {
     "name": "Chirag Jain",


### PR DESCRIPTION
This is a breaking change that requires `InAppUtils.purchaseFinish` to be called to finalize a transaction, where before this was called automatically prior to the `purchaseProduct` callback being fired. The method `getPendingPurchases` to retrieve all unfinished transactions has also been added.