### PR TITLE
In-app purchases promotion

### DIFF
--- a/InAppUtils/InAppUtils.h
+++ b/InAppUtils/InAppUtils.h
@@ -2,7 +2,8 @@
 #import <StoreKit/StoreKit.h>
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface InAppUtils : NSObject <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@interface InAppUtils : RCTEventEmitter <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
 
 @end

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -286,26 +286,22 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                     
                     introductoryPricePrice = item.introductoryPrice.price;
                     introductoryPriceSubscriptionNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long) item.introductoryPrice.subscriptionPeriod.numberOfUnits];
+                    introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.numberOfPeriods) stringValue];
                     
                     switch (item.introductoryPrice.paymentMode) {
                         case SKProductDiscountPaymentModeFreeTrial:
                             introductoryPricePaymentMode = @"FREETRIAL";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
                             break;
                         case SKProductDiscountPaymentModePayAsYouGo:
                             introductoryPricePaymentMode = @"PAYASYOUGO";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.numberOfPeriods) stringValue];
                             break;
                         case SKProductDiscountPaymentModePayUpFront:
                             introductoryPricePaymentMode = @"PAYUPFRONT";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
                             break;
                         default:
-                            introductoryPricePaymentMode = @"";
-                            introductoryPriceNumberOfPeriods = @"0";
+                            introductoryPricePaymentMode = @"";                            
                             break;
                     }
-                    
                     
                     if (item.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitDay) {
                         introductoryPriceSubscriptionUnit = @"DAY";
@@ -398,23 +394,21 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             formatter.locale = discount.priceLocale;
             localizedPrice = [formatter stringFromNumber:discount.price];
             NSString *numberOfPeriods;
-
+            
+            numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
+            
             switch (discount.paymentMode) {
                 case SKProductDiscountPaymentModeFreeTrial:
                     paymendMode = @"FREETRIAL";
-                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
                     break;
                 case SKProductDiscountPaymentModePayAsYouGo:
                     paymendMode = @"PAYASYOUGO";
-                    numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
                     break;
                 case SKProductDiscountPaymentModePayUpFront:
                     paymendMode = @"PAYUPFRONT";
-                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
                     break;
                 default:
                     paymendMode = @"";
-                    numberOfPeriods = @"0";
                     break;
             }
 

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -245,7 +245,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 }
             
             
-            NSString* introductoryPricePrice = @"";
+            NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];
             NSString* introductoryPriceIdentifier = @"";
             NSString* introductoryPricePaymentMode = @"";
             NSString* introductoryPriceNumberOfPeriods = @"";
@@ -256,20 +256,16 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             NSString* subscriptionPeriodNumberOfUnits = @"";
             NSString* subscriptionPeriodUnit= @"";
             
-            NSString* sfrontCountryCode= @"";
-            NSString* sfrontIdentifier= @"";
+            NSString* countryCode= @"";
             
             
             if (@available(iOS 13.0, *)) {
                 SKStorefront * sfront;
-                sfrontCountryCode = sfront.countryCode ? sfront.countryCode : @"";
-                sfrontIdentifier = sfront.identifier ? sfront.identifier : @"";
+                countryCode = sfront.countryCode ? sfront.countryCode : @"";
+            }else{
+                countryCode = [item.priceLocale objectForKey: NSLocaleCountryCode];
             }
             
-            NSDictionary *storeFront = @{
-                @"countryCode": sfrontCountryCode,
-                @"identifier": sfrontIdentifier,
-            };
             
             if (@available(iOS 11.2, *)) {
                 switch (item.subscriptionPeriod.unit) {
@@ -296,7 +292,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 if(item.introductoryPrice != nil){
                     
                     formatter.locale = item.introductoryPrice.priceLocale;
-                    introductoryPricePrice = [formatter stringFromNumber:item.introductoryPrice.price];
+                    introductoryPricePrice = item.introductoryPrice.price;
                     introductoryPriceSubscriptionNumberOfUnit = [NSString stringWithFormat:@"%li",  item.introductoryPrice.subscriptionPeriod.numberOfUnits];
                     
                     switch (item.introductoryPrice.paymentMode) {
@@ -371,13 +367,12 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             };
           
             NSDictionary *product = @{
-                @"storeFront": storeFront,
                 @"identifier": item.productIdentifier,
                 @"price": item.price,
                 @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                 @"currencyCode": currencyCode,
                 @"priceString": item.priceString,
-                @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
+                @"countryCode": countryCode,
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                 @"description": item.localizedDescription ? item.localizedDescription : @"",
                 @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -259,8 +259,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             
             
             if (@available(iOS 13.0, *)) {
-                SKStorefront * sfront;
-                countryCode = sfront.countryCode ? sfront.countryCode : @"";
+                countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
             }else{
                 countryCode = [item.priceLocale objectForKey: NSLocaleCountryCode];
             }

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -229,10 +229,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
         products = [NSMutableArray arrayWithArray:response.products];
         NSMutableArray *productsArrayForJS = [NSMutableArray array];
         for(SKProduct *item in response.products) {
-            NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-               formatter.numberStyle = NSNumberFormatterCurrencyStyle;
-               formatter.locale = item.priceLocale;
-            
+                        
             NSArray *discounts;
             
             if (@available(iOS 12.2, *)) {
@@ -290,8 +287,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
               
                 
                 if(item.introductoryPrice != nil){
-                    
-                    formatter.locale = item.introductoryPrice.priceLocale;
+                                        
                     introductoryPricePrice = item.introductoryPrice.price;
                     introductoryPriceSubscriptionNumberOfUnit = [NSString stringWithFormat:@"%li",  item.introductoryPrice.subscriptionPeriod.numberOfUnits];
                     

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -235,7 +235,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
                                       @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
-                                      @"downloadable": item.downloadable ? @"true" : @"false" ,
+                                      @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",
                                       };

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -242,21 +242,11 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             if (@available(iOS 10.0, *)) {
                 currencyCode = item.priceLocale.currencyCode;
             }
-            
-            
-            NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];
-            NSString* introductoryPriceIdentifier = @"";
-            NSString* introductoryPricePaymentMode = @"";
-            NSString* introductoryPriceNumberOfPeriods = @"";
-            NSString* introductoryPriceSubscriptionUnit = @"";
-            NSString* introductoryPriceType= @"";
-            NSString* introductoryPriceSubscriptionNumberOfUnit = @"";
-            
-            NSString* subscriptionPeriodNumberOfUnits = @"";
-            NSString* subscriptionPeriodUnit= @"";
-            
-            NSString* countryCode= @"";
-            
+
+            NSString *subscriptionPeriodNumberOfUnits = @"";
+            NSString *subscriptionPeriodUnit= @"";
+            NSString *countryCode= @"";
+            NSDictionary *introductoryPrice = nil;
             
             if (@available(iOS 13.0, *)) {
                 countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
@@ -283,14 +273,19 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                         subscriptionPeriodUnit = @"";
                     }
                 
-                subscriptionPeriodNumberOfUnits = [NSString stringWithFormat:@"%li",  item.subscriptionPeriod.numberOfUnits];
-                
-              
+                subscriptionPeriodNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long)item.subscriptionPeriod.numberOfUnits];
                 
                 if(item.introductoryPrice != nil){
-                                        
+                    NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];
+                    NSString* introductoryPriceIdentifier = @"";
+                    NSString* introductoryPricePaymentMode = @"";
+                    NSString* introductoryPriceNumberOfPeriods = @"";
+                    NSString* introductoryPriceSubscriptionUnit = @"";
+                    NSString* introductoryPriceType= @"";
+                    NSString* introductoryPriceSubscriptionNumberOfUnits = @"";
+                    
                     introductoryPricePrice = item.introductoryPrice.price;
-                    introductoryPriceSubscriptionNumberOfUnit = [NSString stringWithFormat:@"%li",  item.introductoryPrice.subscriptionPeriod.numberOfUnits];
+                    introductoryPriceSubscriptionNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long) item.introductoryPrice.subscriptionPeriod.numberOfUnits];
                     
                     switch (item.introductoryPrice.paymentMode) {
                         case SKProductDiscountPaymentModeFreeTrial:
@@ -340,27 +335,28 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                             break;
                         }
                     }
+                    
+                    NSDictionary *introductoryPriceSubscriptionPeriod = @{
+                            @"unit": introductoryPriceSubscriptionUnit,
+                            @"numberOfUnits":introductoryPriceSubscriptionNumberOfUnits,
+                    };
+                    
+                    introductoryPrice = @{
+                        @"identifier": introductoryPriceIdentifier,
+                        @"type": introductoryPriceType,
+                        @"price": introductoryPricePrice,
+                        @"paymentMode": introductoryPricePaymentMode,
+                        @"numberOfPeriods": introductoryPriceNumberOfPeriods,
+                        @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
+                    };
+                }else{
+                    introductoryPrice = @{};
                 }
-                
             }
-            
-            NSDictionary *introductoryPriceSubscriptionPeriod = @{
-                    @"unit": introductoryPriceSubscriptionUnit,
-                    @"numberOfUnit":introductoryPriceSubscriptionNumberOfUnit,
-            };
-            
-            NSDictionary *introductoryPrice = @{
-                @"identifier": introductoryPriceIdentifier,
-                @"type": introductoryPriceType,
-                @"price": introductoryPricePrice,
-                @"paymentMode": introductoryPricePaymentMode,
-                @"numberOfPeriods": introductoryPriceNumberOfPeriods,
-                @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
-            };
-            
+                        
             NSDictionary *subscriptionPeriod = @{
                 @"unit": subscriptionPeriodUnit,
-                @"numberOfUnit":subscriptionPeriodNumberOfUnits,
+                @"numberOfUnits":subscriptionPeriodNumberOfUnits,
             };
           
             NSDictionary *product = @{
@@ -374,7 +370,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"description": item.localizedDescription ? item.localizedDescription : @"",
                 @"title": item.localizedTitle ? item.localizedTitle : @"",
                 @"discounts": discounts ? discounts: @"",
-                @"introductoryPrice": introductoryPrice,
+                @"introductoryPrice":  introductoryPrice,
                 @"subscriptionPeriod": subscriptionPeriod,
             };
             

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -6,8 +6,14 @@
 
 @implementation InAppUtils
 {
+    bool hasListeners;
+    
     NSArray *products;
     NSMutableDictionary *_callbacks;
+    
+    //Promoted in-app purchase
+    SKProduct *promotedProduct;
+    SKPayment *promotedProductPayment;
 }
 
 - (instancetype)init
@@ -25,6 +31,19 @@
 }
 
 RCT_EXPORT_MODULE()
+
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[@"OnPromotedProduct"];
+}
+
+-(void)startObserving {
+    hasListeners = YES;
+}
+
+-(void)stopObserving {
+    hasListeners = NO;
+}
 
 - (void)paymentQueue:(SKPaymentQueue *)queue
  updatedTransactions:(NSArray *)transactions
@@ -254,6 +273,33 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
     }
     
     return purchase;
+}
+
+#pragma mark In-app purchases promotion
+
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product {
+    promotedProduct = product;
+    promotedProductPayment = payment;
+    if(hasListeners) {
+        [self sendEventWithName:@"OnPromotedProduct" body:payment.productIdentifier];
+    }
+    return false;
+}
+
+RCT_EXPORT_METHOD(getPromotedProduct: (RCTResponseSenderBlock)callback)
+{
+    callback(@[promotedProduct ? promotedProduct.productIdentifier : [NSNull null]]);
+}
+
+RCT_EXPORT_METHOD(buyPromotedProduct:(RCTResponseSenderBlock)callback)
+{
+    if(promotedProductPayment) {
+        [[SKPaymentQueue defaultQueue] addPayment:promotedProductPayment];
+        _callbacks[RCTKeyForInstance(promotedProductPayment.productIdentifier)] = callback;
+    }
+    else {
+        callback(@[@"no_initial_product"]);
+    }
 }
 
 - (void)dealloc

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -345,9 +345,11 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                         @"numberOfPeriods": introductoryPriceNumberOfPeriods,
                         @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
                     };
-                }else{
+                } else {
                     introductoryPrice = @{};
                 }
+            } else {
+                introductoryPrice = @{};
             }
                         
             NSDictionary *subscriptionPeriod = @{

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -237,9 +237,10 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             }
             
             NSString* currencyCode = @"";
-                if (@available(iOS 10.0, *)) {
-                    currencyCode = item.priceLocale.currencyCode;
-                }
+            
+            if (@available(iOS 10.0, *)) {
+                currencyCode = item.priceLocale.currencyCode;
+            }
             
             
             NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE()
     for (SKPaymentTransaction *transaction in transactions) {
         switch (transaction.transactionState) {
             case SKPaymentTransactionStateFailed: {
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                NSString *key = transaction.payment.productIdentifier;
                 RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
                     callback(@[RCTJSErrorFromNSError(transaction.error)]);
@@ -64,7 +64,7 @@ RCT_EXPORT_MODULE()
                 break;
             }
             case SKPaymentTransactionStatePurchased: {
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                NSString *key = transaction.payment.productIdentifier;
                 RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
                     NSDictionary *purchase = [self getPurchaseData:transaction];
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
             payment.applicationUsername = username;
         }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
-        _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
+        _callbacks[payment.productIdentifier] = callback;
     } else {
         callback(@[@"invalid_product"]);
     }
@@ -132,7 +132,7 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
 - (void)paymentQueue:(SKPaymentQueue *)queue
 restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
-    NSString *key = RCTKeyForInstance(@"restoreRequest");
+    NSString *key = @"restoreRequest";
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
         switch (error.code)
@@ -153,7 +153,7 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
 {
-    NSString *key = RCTKeyForInstance(@"restoreRequest");
+    NSString *key = @"restoreRequest";
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
         NSMutableArray *productsArrayForJS = [NSMutableArray array];
@@ -176,7 +176,7 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
 RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)callback)
 {
     NSString *restoreRequest = @"restoreRequest";
-    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    _callbacks[restoreRequest] = callback;
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
@@ -184,7 +184,7 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
                     callback:(RCTResponseSenderBlock)callback)
 {
     NSString *restoreRequest = @"restoreRequest";
-    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    _callbacks[restoreRequest] = callback;
     if(!username) {
         callback(@[@"username_required"]);
         return;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -227,7 +227,8 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
         products = [NSMutableArray arrayWithArray:response.products];
-        NSMutableArray *productsArrayForJS = [NSMutableArray array];
+        NSMutableArray *productsArrayForJS = [[NSMutableArray alloc] init];
+        
         for(SKProduct *item in response.products) {
                         
             NSArray *discounts;
@@ -373,7 +374,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                 @"description": item.localizedDescription ? item.localizedDescription : @"",
                 @"title": item.localizedTitle ? item.localizedTitle : @"",
-                @"discounts": discounts,
+                @"discounts": discounts ? discounts: @"",
                 @"introductoryPrice": introductoryPrice,
                 @"subscriptionPeriod": subscriptionPeriod,
             };

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -354,7 +354,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                         
             NSDictionary *subscriptionPeriod = @{
                 @"unit": subscriptionPeriodUnit,
-                @"numberOfUnits":subscriptionPeriodNumberOfUnits,
+                @"numberOfUnits":subscriptionPeriodNumberOfUnits ? subscriptionPeriodNumberOfUnits : @"",
             };
           
             NSDictionary *product = @{

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -363,7 +363,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                 @"currencyCode": currencyCode,
                 @"priceString": item.priceString,
-                @"countryCode": countryCode,
+                @"countryCode": countryCode ? countryCode : @"",
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                 @"description": item.localizedDescription ? item.localizedDescription : @"",
                 @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -237,23 +237,12 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 discounts = [self getDiscountData:[item.discounts copy]];
             }
             
-            NSString* currencyCode = @"";
-            
-            if (@available(iOS 10.0, *)) {
-                currencyCode = item.priceLocale.currencyCode;
-            }
+            NSString* currencyCode = [item.priceLocale objectForKey:NSLocaleCurrencyCode];
+            NSString* countryCode = [item.priceLocale objectForKey:NSLocaleCountryCode];
 
             NSString *subscriptionPeriodNumberOfUnits = @"";
             NSString *subscriptionPeriodUnit= @"";
-            NSString *countryCode= @"";
             NSDictionary *introductoryPrice = nil;
-            
-            if (@available(iOS 13.0, *)) {
-                countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
-            }else{
-                countryCode = [item.priceLocale objectForKey: NSLocaleCountryCode];
-            }
-            
             
             if (@available(iOS 11.2, *)) {
                 switch (item.subscriptionPeriod.unit) {
@@ -361,7 +350,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"identifier": item.productIdentifier,
                 @"price": item.price,
                 @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
-                @"currencyCode": currencyCode,
+                @"currencyCode": currencyCode ? currencyCode : @"",
                 @"priceString": item.priceString,
                 @"countryCode": countryCode ? countryCode : @"",
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -259,11 +259,14 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
+    NSData *dataReceipt = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+    NSString *receipt = [dataReceipt base64EncodedStringWithOptions:0];
+
     NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": receipt
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/Readme.md
+++ b/Readme.md
@@ -173,6 +173,60 @@ InAppUtils.canMakePayments((enabled) => {
 
 **Response:** The enabled boolean flag.
 
+### Get promoted in-app purchase
+
+Gets the promoted product identifier.
+
+```javascript
+InAppUtils.getPromotedProduct((productId) => {
+if(productId) {
+// Handle promoted product
+} else {
+Alert.alert('No promoted product');
+}
+});
+```
+
+**Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
+
+### Buy promoted in-app purchase
+
+Initiates the payment process for the promoted product.
+
+```javascript
+InAppUtils.buyPromotedProduct((error, response) => {
+// NOTE for v3.0: User can cancel the payment which will be available as error object here.
+if(response && response.productIdentifier) {
+Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+//unlock store here.
+}
+});
+```
+
+**Response:** A transaction object with the same fields as `buyProduct`.
+
+### Listen to promoted in-app purchase
+
+If the user taps on a promoted product the app wil be opened and an event will be triggered. To listen to this event you need to setup the `NativeEventEmitter`.
+
+Add `NativeEventEmitter` to you import block and create the emitter.
+```
+import { NativeEventEmitter, NativeModules } from 'react-native'
+const { InAppUtils } = NativeModules
+const inAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
+```
+
+Add a listener:
+```javascript
+inAppUtilsEmitter.addListener('OnPromotedProduct', (productId) => {
+// Handle promoted product
+});
+```
+
+**NOTE:** It's worth to check the native event documentation from React Native to understand how the events work:
+https://facebook.github.io/react-native/docs/native-modules-ios.html#sending-events-to-javascript
+
+**Response:** Returns the promoted product identifier.
 
 ## Testing
 

--- a/Readme.md
+++ b/Readme.md
@@ -187,6 +187,9 @@ InAppUtils.getPromotedProduct((productId) => {
 });
 ```
 
+**NOTE:** The promoted product functions are related to the Promoting Your In-App Purchases feature.
+https://developer.apple.com/app-store/promoting-in-app-purchases/
+
 **Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
 
 ### Buy promoted product
@@ -237,6 +240,13 @@ To test your in-app purchases, you have to *run the app on an actual device*. Us
 2. Run your app on an actual iOS device. To do so, first [run the react-native server on the local network](https://facebook.github.io/react-native/docs/runningondevice.html) instead of localhost. Then connect your iDevice to your Mac via USB and [select it from the list of available devices and simulators](https://i.imgur.com/6ifsu8Q.jpg) in the very top bar. (Next to the build and stop buttons)
 
 3. Open the app and buy something with your Sandbox Tester Apple Account!
+
+### Testing Promoted In-App Purchases
+To test the promoted in-app purchases you can use this link, fill the bundle id and the product identifier and then open the link on a device:
+`itms-services://?action=purchaseIntent&bundleId=<BUNDLE_ID>&productIdentifier=<PRODUCT_IDENTIFIER>`
+
+Check the documentation here:
+https://developer.apple.com/documentation/storekit/in_app_purchase/testing_promoted_in_app_purchases?language=objc
 
 ## Monthly Subscriptions
 

--- a/Readme.md
+++ b/Readme.md
@@ -173,39 +173,39 @@ InAppUtils.canMakePayments((enabled) => {
 
 **Response:** The enabled boolean flag.
 
-### Get promoted in-app purchase
+### Get promoted product
 
 Gets the promoted product identifier.
 
 ```javascript
 InAppUtils.getPromotedProduct((productId) => {
-if(productId) {
-// Handle promoted product
-} else {
-Alert.alert('No promoted product');
-}
+   if(productId) {
+      // Handle promoted product
+   } else {
+      Alert.alert('No promoted product');
+   }
 });
 ```
 
 **Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
 
-### Buy promoted in-app purchase
+### Buy promoted product
 
 Initiates the payment process for the promoted product.
 
 ```javascript
 InAppUtils.buyPromotedProduct((error, response) => {
-// NOTE for v3.0: User can cancel the payment which will be available as error object here.
-if(response && response.productIdentifier) {
-Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
-//unlock store here.
-}
+   // NOTE for v3.0: User can cancel the payment which will be available as error object here.
+   if(response && response.productIdentifier) {
+      Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+      //unlock store here.
+   }
 });
 ```
 
 **Response:** A transaction object with the same fields as `buyProduct`.
 
-### Listen to promoted in-app purchase
+### Listen to promoted product
 
 If the user taps on a promoted product the app wil be opened and an event will be triggered. To listen to this event you need to setup the `NativeEventEmitter`.
 
@@ -219,7 +219,7 @@ const inAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 Add a listener:
 ```javascript
 inAppUtilsEmitter.addListener('OnPromotedProduct', (productId) => {
-// Handle promoted product
+   // Handle promoted product
 });
 ```
 


### PR DESCRIPTION
I've added some functionality to the library to support the new feature of the in-app purchases promotion. Basically I added a couple of functions to get the promoted product and to trigger the purchase.

The most special part is how you get notified when the app is opened from a promoted product, I solved this by implementing `RCTEventEmitter` in the class.

Closes #178 