### PR TITLE
Improved variable naming in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ const { InAppUtils } = NativeModules
 You have to load the products first to get the correctly internationalized name and price in the correct currency.
 
 ```javascript
-var identifiers = [
+const identifiers = [
    'com.xyz.abc',
 ];
 InAppUtils.loadProducts(identifiers, (error, products) => {

--- a/Readme.md
+++ b/Readme.md
@@ -34,10 +34,11 @@ const { InAppUtils } = NativeModules
 You have to load the products first to get the correctly internationalized name and price in the correct currency.
 
 ```javascript
-var products = [
+var identifiers = [
    'com.xyz.abc',
 ];
-InAppUtils.loadProducts(products, (error, products) => {
+InAppUtils.loadProducts(identifiers, (error, products) => {
+   console.log(products);
    //update store here.
 });
 ```


### PR DESCRIPTION
I feel this is better than re-using `products` for two things. This really confused me initially.