### PR TITLE
Fix/missing currency code and country code

### DIFF
--- a/InAppUtils/InAppUtils.h
+++ b/InAppUtils/InAppUtils.h
@@ -2,7 +2,8 @@
 #import <StoreKit/StoreKit.h>
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface InAppUtils : NSObject <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@interface InAppUtils : RCTEventEmitter <RCTBridgeModule, SKProductsRequestDelegate, SKPaymentTransactionObserver>
 
 @end

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -286,26 +286,22 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                     
                     introductoryPricePrice = item.introductoryPrice.price;
                     introductoryPriceSubscriptionNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long) item.introductoryPrice.subscriptionPeriod.numberOfUnits];
+                    introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.numberOfPeriods) stringValue];
                     
                     switch (item.introductoryPrice.paymentMode) {
                         case SKProductDiscountPaymentModeFreeTrial:
                             introductoryPricePaymentMode = @"FREETRIAL";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
                             break;
                         case SKProductDiscountPaymentModePayAsYouGo:
                             introductoryPricePaymentMode = @"PAYASYOUGO";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.numberOfPeriods) stringValue];
                             break;
                         case SKProductDiscountPaymentModePayUpFront:
                             introductoryPricePaymentMode = @"PAYUPFRONT";
-                            introductoryPriceNumberOfPeriods = [@(item.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
                             break;
                         default:
-                            introductoryPricePaymentMode = @"";
-                            introductoryPriceNumberOfPeriods = @"0";
+                            introductoryPricePaymentMode = @"";                            
                             break;
                     }
-                    
                     
                     if (item.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitDay) {
                         introductoryPriceSubscriptionUnit = @"DAY";
@@ -398,23 +394,21 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             formatter.locale = discount.priceLocale;
             localizedPrice = [formatter stringFromNumber:discount.price];
             NSString *numberOfPeriods;
-
+            
+            numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
+            
             switch (discount.paymentMode) {
                 case SKProductDiscountPaymentModeFreeTrial:
                     paymendMode = @"FREETRIAL";
-                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
                     break;
                 case SKProductDiscountPaymentModePayAsYouGo:
                     paymendMode = @"PAYASYOUGO";
-                    numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
                     break;
                 case SKProductDiscountPaymentModePayUpFront:
                     paymendMode = @"PAYUPFRONT";
-                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
                     break;
                 default:
                     paymendMode = @"";
-                    numberOfPeriods = @"0";
                     break;
             }
 

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -191,15 +191,11 @@ RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
 RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers
                   callback:(RCTResponseSenderBlock)callback)
 {
-    if([SKPaymentQueue canMakePayments]){
-        SKProductsRequest *productsRequest = [[SKProductsRequest alloc]
-                                              initWithProductIdentifiers:[NSSet setWithArray:productIdentifiers]];
-        productsRequest.delegate = self;
-        _callbacks[RCTKeyForInstance(productsRequest)] = callback;
-        [productsRequest start];
-    } else {
-        callback(@[@"not_available"]);
-    }
+    SKProductsRequest *productsRequest = [[SKProductsRequest alloc]
+                                          initWithProductIdentifiers:[NSSet setWithArray:productIdentifiers]];
+    productsRequest.delegate = self;
+    _callbacks[RCTKeyForInstance(productsRequest)] = callback;
+    [productsRequest start];
 }
 
 RCT_EXPORT_METHOD(canMakePayments: (RCTResponseSenderBlock)callback)

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -235,7 +235,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
                                       @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
-                                      @"downloadable": item.downloadable ? @"true" : @"false" ,
+                                      @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",
                                       };

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -242,21 +242,11 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
             if (@available(iOS 10.0, *)) {
                 currencyCode = item.priceLocale.currencyCode;
             }
-            
-            
-            NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];
-            NSString* introductoryPriceIdentifier = @"";
-            NSString* introductoryPricePaymentMode = @"";
-            NSString* introductoryPriceNumberOfPeriods = @"";
-            NSString* introductoryPriceSubscriptionUnit = @"";
-            NSString* introductoryPriceType= @"";
-            NSString* introductoryPriceSubscriptionNumberOfUnit = @"";
-            
-            NSString* subscriptionPeriodNumberOfUnits = @"";
-            NSString* subscriptionPeriodUnit= @"";
-            
-            NSString* countryCode= @"";
-            
+
+            NSString *subscriptionPeriodNumberOfUnits = @"";
+            NSString *subscriptionPeriodUnit= @"";
+            NSString *countryCode= @"";
+            NSDictionary *introductoryPrice = nil;
             
             if (@available(iOS 13.0, *)) {
                 countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
@@ -283,14 +273,19 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                         subscriptionPeriodUnit = @"";
                     }
                 
-                subscriptionPeriodNumberOfUnits = [NSString stringWithFormat:@"%li",  item.subscriptionPeriod.numberOfUnits];
-                
-              
+                subscriptionPeriodNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long)item.subscriptionPeriod.numberOfUnits];
                 
                 if(item.introductoryPrice != nil){
-                                        
+                    NSDecimalNumber* introductoryPricePrice = [NSDecimalNumber zero];
+                    NSString* introductoryPriceIdentifier = @"";
+                    NSString* introductoryPricePaymentMode = @"";
+                    NSString* introductoryPriceNumberOfPeriods = @"";
+                    NSString* introductoryPriceSubscriptionUnit = @"";
+                    NSString* introductoryPriceType= @"";
+                    NSString* introductoryPriceSubscriptionNumberOfUnits = @"";
+                    
                     introductoryPricePrice = item.introductoryPrice.price;
-                    introductoryPriceSubscriptionNumberOfUnit = [NSString stringWithFormat:@"%li",  item.introductoryPrice.subscriptionPeriod.numberOfUnits];
+                    introductoryPriceSubscriptionNumberOfUnits = [NSString stringWithFormat:@"%lu",  (unsigned long) item.introductoryPrice.subscriptionPeriod.numberOfUnits];
                     
                     switch (item.introductoryPrice.paymentMode) {
                         case SKProductDiscountPaymentModeFreeTrial:
@@ -340,27 +335,28 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                             break;
                         }
                     }
+                    
+                    NSDictionary *introductoryPriceSubscriptionPeriod = @{
+                            @"unit": introductoryPriceSubscriptionUnit,
+                            @"numberOfUnits":introductoryPriceSubscriptionNumberOfUnits,
+                    };
+                    
+                    introductoryPrice = @{
+                        @"identifier": introductoryPriceIdentifier,
+                        @"type": introductoryPriceType,
+                        @"price": introductoryPricePrice,
+                        @"paymentMode": introductoryPricePaymentMode,
+                        @"numberOfPeriods": introductoryPriceNumberOfPeriods,
+                        @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
+                    };
+                }else{
+                    introductoryPrice = @{};
                 }
-                
             }
-            
-            NSDictionary *introductoryPriceSubscriptionPeriod = @{
-                    @"unit": introductoryPriceSubscriptionUnit,
-                    @"numberOfUnit":introductoryPriceSubscriptionNumberOfUnit,
-            };
-            
-            NSDictionary *introductoryPrice = @{
-                @"identifier": introductoryPriceIdentifier,
-                @"type": introductoryPriceType,
-                @"price": introductoryPricePrice,
-                @"paymentMode": introductoryPricePaymentMode,
-                @"numberOfPeriods": introductoryPriceNumberOfPeriods,
-                @"subscriptionPeriod": introductoryPriceSubscriptionPeriod,
-            };
-            
+                        
             NSDictionary *subscriptionPeriod = @{
                 @"unit": subscriptionPeriodUnit,
-                @"numberOfUnit":subscriptionPeriodNumberOfUnits,
+                @"numberOfUnits":subscriptionPeriodNumberOfUnits,
             };
           
             NSDictionary *product = @{
@@ -374,7 +370,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"description": item.localizedDescription ? item.localizedDescription : @"",
                 @"title": item.localizedTitle ? item.localizedTitle : @"",
                 @"discounts": discounts ? discounts: @"",
-                @"introductoryPrice": introductoryPrice,
+                @"introductoryPrice":  introductoryPrice,
                 @"subscriptionPeriod": subscriptionPeriod,
             };
             

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -6,8 +6,14 @@
 
 @implementation InAppUtils
 {
+    bool hasListeners;
+    
     NSArray *products;
     NSMutableDictionary *_callbacks;
+    
+    //Promoted in-app purchase
+    SKProduct *promotedProduct;
+    SKPayment *promotedProductPayment;
 }
 
 - (instancetype)init
@@ -25,6 +31,19 @@
 }
 
 RCT_EXPORT_MODULE()
+
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[@"OnPromotedProduct"];
+}
+
+-(void)startObserving {
+    hasListeners = YES;
+}
+
+-(void)stopObserving {
+    hasListeners = NO;
+}
 
 - (void)paymentQueue:(SKPaymentQueue *)queue
  updatedTransactions:(NSArray *)transactions
@@ -254,6 +273,33 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
     }
     
     return purchase;
+}
+
+#pragma mark In-app purchases promotion
+
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product {
+    promotedProduct = product;
+    promotedProductPayment = payment;
+    if(hasListeners) {
+        [self sendEventWithName:@"OnPromotedProduct" body:payment.productIdentifier];
+    }
+    return false;
+}
+
+RCT_EXPORT_METHOD(getPromotedProduct: (RCTResponseSenderBlock)callback)
+{
+    callback(@[promotedProduct ? promotedProduct.productIdentifier : [NSNull null]]);
+}
+
+RCT_EXPORT_METHOD(buyPromotedProduct:(RCTResponseSenderBlock)callback)
+{
+    if(promotedProductPayment) {
+        [[SKPaymentQueue defaultQueue] addPayment:promotedProductPayment];
+        _callbacks[RCTKeyForInstance(promotedProductPayment.productIdentifier)] = callback;
+    }
+    else {
+        callback(@[@"no_initial_product"]);
+    }
 }
 
 - (void)dealloc

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -76,8 +76,22 @@ RCT_EXPORT_MODULE()
     }
 }
 
+RCT_EXPORT_METHOD(purchaseProductForUser:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:username callback:callback];
+}
+
 RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
                   callback:(RCTResponseSenderBlock)callback)
+{
+    [self doPurchaseProduct:productIdentifier username:nil callback:callback];
+}
+
+- (void) doPurchaseProduct:(NSString *)productIdentifier
+                  username:(NSString *)username
+                  callback:(RCTResponseSenderBlock)callback
 {
     SKProduct *product;
     for(SKProduct *p in products)
@@ -89,7 +103,10 @@ RCT_EXPORT_METHOD(purchaseProduct:(NSString *)productIdentifier
     }
 
     if(product) {
-        SKPayment *payment = [SKPayment paymentWithProduct:product];
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        if(username) {
+            payment.applicationUsername = username;
+        }
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         _callbacks[RCTKeyForInstance(payment.productIdentifier)] = callback;
     } else {
@@ -159,6 +176,18 @@ RCT_EXPORT_METHOD(restorePurchases:(RCTResponseSenderBlock)callback)
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
+RCT_EXPORT_METHOD(restorePurchasesForUser:(NSString *)username
+                    callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *restoreRequest = @"restoreRequest";
+    _callbacks[RCTKeyForInstance(restoreRequest)] = callback;
+    if(!username) {
+        callback(@[@"username_required"]);
+        return;
+    }
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactionsWithApplicationUsername:username];
+}
+
 RCT_EXPORT_METHOD(loadProducts:(NSArray *)productIdentifiers
                   callback:(RCTResponseSenderBlock)callback)
 {
@@ -206,6 +235,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
+                                      @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
                                       @"downloadable": item.downloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -237,23 +237,12 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 discounts = [self getDiscountData:[item.discounts copy]];
             }
             
-            NSString* currencyCode = @"";
-            
-            if (@available(iOS 10.0, *)) {
-                currencyCode = item.priceLocale.currencyCode;
-            }
+            NSString* currencyCode = [item.priceLocale objectForKey:NSLocaleCurrencyCode];
+            NSString* countryCode = [item.priceLocale objectForKey:NSLocaleCountryCode];
 
             NSString *subscriptionPeriodNumberOfUnits = @"";
             NSString *subscriptionPeriodUnit= @"";
-            NSString *countryCode= @"";
             NSDictionary *introductoryPrice = nil;
-            
-            if (@available(iOS 13.0, *)) {
-                countryCode = [[SKPaymentQueue defaultQueue] storefront].countryCode;
-            }else{
-                countryCode = [item.priceLocale objectForKey: NSLocaleCountryCode];
-            }
-            
             
             if (@available(iOS 11.2, *)) {
                 switch (item.subscriptionPeriod.unit) {
@@ -361,7 +350,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                 @"identifier": item.productIdentifier,
                 @"price": item.price,
                 @"currencySymbol": [item.priceLocale objectForKey:NSLocaleCurrencySymbol],
-                @"currencyCode": currencyCode,
+                @"currencyCode": currencyCode ? currencyCode : @"",
                 @"priceString": item.priceString,
                 @"countryCode": countryCode ? countryCode : @"",
                 @"downloadable": item.isDownloadable ? @"true" : @"false" ,

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -47,12 +47,7 @@ RCT_EXPORT_MODULE()
                 NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
                 RCTResponseSenderBlock callback = _callbacks[key];
                 if (callback) {
-                    NSDictionary *purchase = @{
-                                              @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
-                                              @"transactionIdentifier": transaction.transactionIdentifier,
-                                              @"productIdentifier": transaction.payment.productIdentifier,
-                                              @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
-                                              };
+                    NSDictionary *purchase = [self getPurchaseData:transaction];
                     callback(@[[NSNull null], purchase]);
                     [_callbacks removeObjectForKey:key];
                 } else {
@@ -145,18 +140,7 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
         for(SKPaymentTransaction *transaction in queue.transactions){
             if(transaction.transactionState == SKPaymentTransactionStateRestored) {
 
-                NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
-                    @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
-                    @"transactionIdentifier": transaction.transactionIdentifier,
-                    @"productIdentifier": transaction.payment.productIdentifier,
-                    @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
-                }];
-
-                SKPaymentTransaction *originalTransaction = transaction.originalTransaction;
-                if (originalTransaction) {
-                    purchase[@"originalTransactionDate"] = @(originalTransaction.transactionDate.timeIntervalSince1970 * 1000);
-                    purchase[@"originalTransactionIdentifier"] = originalTransaction.transactionIdentifier;
-                }
+                NSDictionary *purchase = [self getPurchaseData:transaction];
 
                 [productsArrayForJS addObject:purchase];
                 [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
@@ -253,6 +237,23 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
         callback(@[RCTJSErrorFromNSError(error)]);
         [_callbacks removeObjectForKey:key];
     }
+}
+
+- (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
+    NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
+                                                                                     @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
+                                                                                     @"transactionIdentifier": transaction.transactionIdentifier,
+                                                                                     @"productIdentifier": transaction.payment.productIdentifier,
+                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     }];
+    // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
+    SKPaymentTransaction *originalTransaction = transaction.originalTransaction;
+    if (originalTransaction) {
+        purchase[@"originalTransactionDate"] = @(originalTransaction.transactionDate.timeIntervalSince1970 * 1000);
+        purchase[@"originalTransactionIdentifier"] = originalTransaction.transactionIdentifier;
+    }
+    
+    return purchase;
 }
 
 - (void)dealloc

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -259,11 +259,14 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
+    NSData *dataReceipt = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+    NSString *receipt = [dataReceipt base64EncodedStringWithOptions:0];
+
     NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": receipt
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -103,7 +103,16 @@ restoreCompletedTransactionsFailedWithError:(NSError *)error
     NSString *key = RCTKeyForInstance(@"restoreRequest");
     RCTResponseSenderBlock callback = _callbacks[key];
     if (callback) {
-        callback(@[@"restore_failed"]);
+        switch (error.code)
+        {
+            case SKErrorPaymentCancelled:
+                callback(@[@"user_cancelled"]);
+                break;
+            default:
+                callback(@[@"restore_failed"]);
+                break;
+        }
+        
         [_callbacks removeObjectForKey:key];
     } else {
         RCTLogWarn(@"No callback registered for restore product request.");

--- a/Readme.md
+++ b/Readme.md
@@ -97,11 +97,14 @@ https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-m
 
 | Field                 | Type   | Description                                        |
 | --------------------- | ------ | -------------------------------------------------- |
+| originalTransactionDate        | number | The original transaction date (ms since epoch)     |
+| originalTransactionIdentifier  | string | The original transaction identifier                |
 | transactionDate       | number | The transaction date (ms since epoch)              |
 | transactionIdentifier | string | The transaction identifier                         |
 | productIdentifier     | string | The product identifier                             |
 | transactionReceipt    | string | The transaction receipt as a base64 encoded string |
 
+**NOTE:**  `originalTransactionDate` and `originalTransactionIdentifier` are only available for subscriptions that were previously cancelled or expired.
 
 ### Restore payments
 

--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,18 @@ InAppUtils.loadProducts(products, (error, products) => {
 
 **Troubleshooting:** If you do not get back your product(s) then there's a good chance that something in your iTunes Connect or Xcode is not properly configured. Take a look at this [StackOverflow Answer](http://stackoverflow.com/a/11707704/293280) to determine what might be the issue(s).
 
+### Checking if payments are allowed
+
+```javascript
+InAppUtils.canMakePayments((canMakePayments) => {
+   if(!canMakePayments) {
+      Alert.alert('Not Allowed', 'This device is not allowed to make purchases. Please check restrictions on device');
+   }
+})
+```
+
+**NOTE:** canMakePayments may return false because of country limitation or parental contol/restriction setup on the device.
+
 ### Buy product
 
 ```javascript
@@ -75,6 +87,8 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 ```
 
 **NOTE:** Call `loadProducts` prior to calling `purchaseProduct`, otherwise this will return `invalid_product`. If you're calling them right after each other, you will need to call `purchaseProduct` inside of the `loadProducts` callback to ensure it has had a chance to complete its call.
+
+**NOTE:** Call `canMakePurchases` prior to calling `purchaseProduct` to ensure that the user is allowed to make a purchase. It is generally a good idea to inform the user that they are not allowed to make purchases from their account and what they can do about it instead of a cryptic error message from iTunes.
 
 **NOTE:** `purchaseProductForUser(productIdentifier, username, callback)` is also available.
 https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858

--- a/Readme.md
+++ b/Readme.md
@@ -173,6 +173,60 @@ InAppUtils.canMakePayments((enabled) => {
 
 **Response:** The enabled boolean flag.
 
+### Get promoted in-app purchase
+
+Gets the promoted product identifier.
+
+```javascript
+InAppUtils.getPromotedProduct((productId) => {
+if(productId) {
+// Handle promoted product
+} else {
+Alert.alert('No promoted product');
+}
+});
+```
+
+**Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
+
+### Buy promoted in-app purchase
+
+Initiates the payment process for the promoted product.
+
+```javascript
+InAppUtils.buyPromotedProduct((error, response) => {
+// NOTE for v3.0: User can cancel the payment which will be available as error object here.
+if(response && response.productIdentifier) {
+Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+//unlock store here.
+}
+});
+```
+
+**Response:** A transaction object with the same fields as `buyProduct`.
+
+### Listen to promoted in-app purchase
+
+If the user taps on a promoted product the app wil be opened and an event will be triggered. To listen to this event you need to setup the `NativeEventEmitter`.
+
+Add `NativeEventEmitter` to you import block and create the emitter.
+```
+import { NativeEventEmitter, NativeModules } from 'react-native'
+const { InAppUtils } = NativeModules
+const inAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
+```
+
+Add a listener:
+```javascript
+inAppUtilsEmitter.addListener('OnPromotedProduct', (productId) => {
+// Handle promoted product
+});
+```
+
+**NOTE:** It's worth to check the native event documentation from React Native to understand how the events work:
+https://facebook.github.io/react-native/docs/native-modules-ios.html#sending-events-to-javascript
+
+**Response:** Returns the promoted product identifier.
 
 ## Testing
 

--- a/Readme.md
+++ b/Readme.md
@@ -187,6 +187,9 @@ InAppUtils.getPromotedProduct((productId) => {
 });
 ```
 
+**NOTE:** The promoted product functions are related to the Promoting Your In-App Purchases feature.
+https://developer.apple.com/app-store/promoting-in-app-purchases/
+
 **Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
 
 ### Buy promoted product
@@ -237,6 +240,13 @@ To test your in-app purchases, you have to *run the app on an actual device*. Us
 2. Run your app on an actual iOS device. To do so, first [run the react-native server on the local network](https://facebook.github.io/react-native/docs/runningondevice.html) instead of localhost. Then connect your iDevice to your Mac via USB and [select it from the list of available devices and simulators](https://i.imgur.com/6ifsu8Q.jpg) in the very top bar. (Next to the build and stop buttons)
 
 3. Open the app and buy something with your Sandbox Tester Apple Account!
+
+### Testing Promoted In-App Purchases
+To test the promoted in-app purchases you can use this link, fill the bundle id and the product identifier and then open the link on a device:
+`itms-services://?action=purchaseIntent&bundleId=<BUNDLE_ID>&productIdentifier=<PRODUCT_IDENTIFIER>`
+
+Check the documentation here:
+https://developer.apple.com/documentation/storekit/in_app_purchase/testing_promoted_in_app_purchases?language=objc
 
 ## Monthly Subscriptions
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,11 +17,9 @@ A react-native wrapper for handling in-app purchases.
 
 ### Add it to your project
 
-1. Make sure you have `rnpm` installed: `npm install rnpm -g`
+1.Install with react-native cli `react-native install react-native-in-app-utils`
 
-2. Install with rnpm: `rnpm install react-native-in-app-utils`
-
-3. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('NativeModules').InAppUtils;`
+2. Whenever you want to use it within React code now you just have to do: `var InAppUtils = require('NativeModules').InAppUtils;`
    or for ES6:
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,7 @@ InAppUtils.loadProducts(products, (error, products) => {
 | currencySymbol | string  | The currency symbol, i.e. "$" or "SEK"      |
 | currencyCode   | string  | The currency code, i.e. "USD" of "SEK"      |
 | priceString    | string  | Localised string of price, i.e. "$1,234.00" |
+| countryCode    | string  | Country code of the price, i.e. "GB" or "FR"|
 | downloadable   | boolean | Whether the purchase is downloadable        |
 | description    | string  | Description string                          |
 | title          | string  | Title string                                |
@@ -74,6 +75,9 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 ```
 
 **NOTE:** Call `loadProducts` prior to calling `purchaseProduct`, otherwise this will return `invalid_product`. If you're calling them right after each other, you will need to call `purchaseProduct` inside of the `loadProducts` callback to ensure it has had a chance to complete its call.
+
+**NOTE:** `purchaseProductForUser(productIdentifier, username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
 
 **Response:** A transaction object with the following fields:
 
@@ -107,6 +111,9 @@ InAppUtils.restorePurchases((error, response) => {
    }
 });
 ```
+
+**NOTE:** `restorePurchasesForUser(username, callback)` is also available.
+https://stackoverflow.com/questions/29255568/is-there-any-way-to-know-purchase-made-by-which-itunes-account-ios/29280858#29280858
 
 **Response:** An array of transaction objects with the following fields:
 

--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ var productIdentifier = 'com.xyz.abc';
 InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
    // NOTE for v3.0: User can cancel the payment which will be available as error object here.
    if(response && response.productIdentifier) {
-      AlertIOS.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+      Alert.alert('Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
       //unlock store here.
    }
 });
@@ -88,19 +88,19 @@ InAppUtils.purchaseProduct(productIdentifier, (error, response) => {
 ### Restore payments
 
 ```javascript
-InAppUtils.restorePurchases((error, response)=> {
+InAppUtils.restorePurchases((error, response) => {
    if(error) {
-      AlertIOS.alert('itunes Error', 'Could not connect to itunes store.');
+      Alert.alert('itunes Error', 'Could not connect to itunes store.');
    } else {
-      AlertIOS.alert('Restore Successful', 'Successfully restores all your purchases.');
+      Alert.alert('Restore Successful', 'Successfully restores all your purchases.');
       
-      if (response.length == 0) {
+      if (response.length === 0) {
         Alert.alert('No Purchases', "We didn't find any purchases to restore.");
         return;
       }
 
-      response.forEach( function(purchase) {
-        if (purchase.productIdentifier == "com.xyz.abc") {
+      response.forEach((purchase) => {
+        if (purchase.productIdentifier === 'com.xyz.abc') {
           // Handle purchased product.
         }
       });
@@ -127,7 +127,7 @@ iTunes receipts are associated to the users iTunes account and can be retrieved 
 ```javascript
 InAppUtils.receiptData((error, receiptData)=> {
   if(error) {
-    AlertIOS.alert('itunes Error', 'Receipt not found.');
+    Alert.alert('itunes Error', 'Receipt not found.');
   } else {
     //send to validation server
   }
@@ -143,9 +143,9 @@ Check if in-app purchases are enabled/disabled.
 ```javascript
 InAppUtils.canMakePayments((enabled) => {
   if(enabled) {
-    AlertIOS.alert('IAP enabled');
+    Alert.alert('IAP enabled');
   } else {
-    AlertIOS.alert('IAP disabled');
+    Alert.alert('IAP disabled');
   }
 });
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -173,39 +173,39 @@ InAppUtils.canMakePayments((enabled) => {
 
 **Response:** The enabled boolean flag.
 
-### Get promoted in-app purchase
+### Get promoted product
 
 Gets the promoted product identifier.
 
 ```javascript
 InAppUtils.getPromotedProduct((productId) => {
-if(productId) {
-// Handle promoted product
-} else {
-Alert.alert('No promoted product');
-}
+   if(productId) {
+      // Handle promoted product
+   } else {
+      Alert.alert('No promoted product');
+   }
 });
 ```
 
 **Response:** Only returns the promoted product identifier if the user taps on a promoted product, otherwise returns null.
 
-### Buy promoted in-app purchase
+### Buy promoted product
 
 Initiates the payment process for the promoted product.
 
 ```javascript
 InAppUtils.buyPromotedProduct((error, response) => {
-// NOTE for v3.0: User can cancel the payment which will be available as error object here.
-if(response && response.productIdentifier) {
-Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
-//unlock store here.
-}
+   // NOTE for v3.0: User can cancel the payment which will be available as error object here.
+   if(response && response.productIdentifier) {
+      Alert.alert('Promoted Purchase Successful', 'Your Transaction ID is ' + response.transactionIdentifier);
+      //unlock store here.
+   }
 });
 ```
 
 **Response:** A transaction object with the same fields as `buyProduct`.
 
-### Listen to promoted in-app purchase
+### Listen to promoted product
 
 If the user taps on a promoted product the app wil be opened and an event will be triggered. To listen to this event you need to setup the `NativeEventEmitter`.
 
@@ -219,7 +219,7 @@ const inAppUtilsEmitter = new NativeEventEmitter(InAppUtils);
 Add a listener:
 ```javascript
 inAppUtilsEmitter.addListener('OnPromotedProduct', (productId) => {
-// Handle promoted product
+   // Handle promoted product
 });
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,7 @@ A react-native wrapper for handling in-app purchases.
 
 # Breaking Change
 
-- Due to a major breaking change in RN 0.40+, Use v5.x of this lib when installing from npm.
-
+- Due to a major breaking change in RN 0.40+, use version 5 or higher of this lib when installing from npm.
 
 # Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-in-app-utils",
-  "version": "5.6.0",
+  "version": "6.0.0",
   "description": "A react-native wrapper for handling in-app payments.",
   "author": {
     "name": "Chirag Jain",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-in-app-utils",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "A react-native wrapper for handling in-app payments.",
   "author": {
     "name": "Chirag Jain",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-in-app-utils",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "A react-native wrapper for handling in-app payments.",
   "author": {
     "name": "Chirag Jain",


### PR DESCRIPTION
### Issues
- https://github.com/lingokids/app/issues/5349
- https://github.com/lingokids/app/issues/5349

### What
This PR fixes two problems.

1. We were using the countryCode provided by the SKStorefront API in iOS 13+ and combing it with the product information returned from the SKProduct API. However, there were occasions where SKStorefront would return nil, which would mean an empty string would be sent to our own backend service. SKProduct actually provides its own method for returning the countryCode for each product, and we already use this on versions of iOS < 13. We have not seen a situation where it was undefined or nil. As such, we have decided to use the countryCode provided by SKProduct in all versions.
2. The second issue was a missing currencyCode on iOS < 10. This was because accessing the property directly is not available on lower versions, however the same value can be fetched using a method that is available on all lower versions. 